### PR TITLE
links to identifiers differing only in case

### DIFF
--- a/src/theme/utils.ts
+++ b/src/theme/utils.ts
@@ -45,6 +45,5 @@ export function getAnchorRef(ref: string) {
   return ref
     .replace(/_|\/|\.| /g, '-')
     .replace(/"/g, '')
-    .replace(/ /g, '-')
-    .toLowerCase();
+    .replace(/ /g, '-');
 }


### PR DESCRIPTION
Currently if there are two identifiers that differ just in case then links are broken. i.e, you have two functions or methods, etc named: "Call" and "call". Then references to the later will be broken because of the toLowerCase()