### PR TITLE
Disable HTML escaping in inline code blocks

### DIFF
--- a/src/theme/partials/member.getterSetter.hbs
+++ b/src/theme/partials/member.getterSetter.hbs
@@ -1,17 +1,18 @@
 {{#if getSignature}}
 {{#with getSignature}}
 {{#compact}}
-get
-{{../name}}
+**get {{../name}}**
 {{> member.signature.title hideName=true }}
 {{/compact}}
 {{/with}}
 {{/if}}
 {{#if setSignature}}
+{{#if getSignature}}
+{{getNewLine}}
+{{/if}}
 {{#with setSignature}}
 {{#compact}}
-set 
-{{../name}}
+**set {{../name}}**
 {{> member.signature.title hideName=true }}
 {{/compact}}
 {{/with}}

--- a/src/theme/partials/type.hbs
+++ b/src/theme/partials/type.hbs
@@ -32,12 +32,12 @@
 {{else}}
 {{#compact}}
 {{#if name}}
-`{{name}}`
+`{{{name}}}`
 {{else}}
 {{#if value}}
 "{{value}}"
 {{else}}
-`{{this}}`
+`{{{this}}}`
 {{/if}}
 {{/if}}
 {{#if typeArguments}}

--- a/test/fixtures/bitbucket/classes/subclassa.md
+++ b/test/fixtures/bitbucket/classes/subclassa.md
@@ -138,7 +138,9 @@ ___
 
 ###  nameProperty
 
-getnameProperty(): `string`setnameProperty(value: *`string`*): `void`
+**get nameProperty**(): `string`
+
+**set nameProperty**(value: *`string`*): `void`
 
 *Defined in [classes.ts:219](https://bitbucket.org/owner/repository_name/src/master/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-219)*
 
@@ -164,7 +166,7 @@ ___
 
 ###  readOnlyNameProperty
 
-getreadOnlyNameProperty(): `string`
+**get readOnlyNameProperty**(): `string`
 
 *Defined in [classes.ts:238](https://bitbucket.org/owner/repository_name/src/master/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-238)*
 
@@ -177,7 +179,7 @@ ___
 
 ###  writeOnlyNameProperty
 
-setwriteOnlyNameProperty(value: *`string`*): `void`
+**set writeOnlyNameProperty**(value: *`string`*): `void`
 
 *Defined in [classes.ts:248](https://bitbucket.org/owner/repository_name/src/master/classes.ts?fileviewer&amp;#x3D;file-view-default#classes.ts-248)*
 

--- a/test/fixtures/gitbook/classes/_classes_.subclassa.md
+++ b/test/fixtures/gitbook/classes/_classes_.subclassa.md
@@ -112,7 +112,9 @@ ___
 
 ##  nameProperty
 
-getnameProperty(): `string`setnameProperty(value: *`string`*): `void`
+**get nameProperty**(): `string`
+
+**set nameProperty**(value: *`string`*): `void`
 
 *Defined in [classes.ts:219](https://github.com/tgreyuk/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L219)*
 
@@ -139,7 +141,7 @@ ___
 
 ##  readOnlyNameProperty
 
-getreadOnlyNameProperty(): `string`
+**get readOnlyNameProperty**(): `string`
 
 *Defined in [classes.ts:238](https://github.com/tgreyuk/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L238)*
 
@@ -153,7 +155,7 @@ ___
 
 ##  writeOnlyNameProperty
 
-setwriteOnlyNameProperty(value: *`string`*): `void`
+**set writeOnlyNameProperty**(value: *`string`*): `void`
 
 *Defined in [classes.ts:248](https://github.com/tgreyuk/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L248)*
 

--- a/test/fixtures/github/classes/_classes_.subclassa.md
+++ b/test/fixtures/github/classes/_classes_.subclassa.md
@@ -147,7 +147,9 @@ ___
 
 ###  nameProperty
 
-getnameProperty(): `string`setnameProperty(value: *`string`*): `void`
+**get nameProperty**(): `string`
+
+**set nameProperty**(value: *`string`*): `void`
 
 *Defined in [classes.ts:219](https://github.com/tgreyuk/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L219)*
 
@@ -174,7 +176,7 @@ ___
 
 ###  readOnlyNameProperty
 
-getreadOnlyNameProperty(): `string`
+**get readOnlyNameProperty**(): `string`
 
 *Defined in [classes.ts:238](https://github.com/tgreyuk/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L238)*
 
@@ -188,7 +190,7 @@ ___
 
 ###  writeOnlyNameProperty
 
-setwriteOnlyNameProperty(value: *`string`*): `void`
+**set writeOnlyNameProperty**(value: *`string`*): `void`
 
 *Defined in [classes.ts:248](https://github.com/tgreyuk/typedoc-plugin-markdown/blob/master/test/src/classes.ts#L248)*
 


### PR DESCRIPTION
Type aliases may be escaped unexpectedly.

For example

```md
**Ƭ TC**: *`() &#x3D;&gt; void`*
```

which should be

```md
**Ƭ TC**: *`() => void`*
```

```
src/theme/partials/parameter.hbs:36:`{{this}}`
src/theme/partials/member.signature.title.hbs:7:`{{name}}`
src/theme/partials/member.parameters.hbs:8:`{{this}}`
src/theme/partials/member.parameters.hbs:15:`{{this}}`
src/theme/partials/member.parameters.hbs:26:`{{this}}`
```

There are some `{{  }}` tags in other files, but seem to not make mistake.