### PR TITLE
VuePress support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ The plugin also attempts to target the following platforms:
 #### VuePress (`--platform vuepress`)
 
 - Adds metadata to rendered Markdown.
-- If the out directory is recognised as a vuepress `/docs` directory, the plugin will create `.vuepress/api-sidebar.json` so pages are accessible in the sidebar.
+- If the out directory is recognised as a VuePress `/docs` directory, the plugin will create
+  - `.vuepress/api-sidebar.json` to be used with [sidebar](https://vuepress.vuejs.org/default-theme-config/#sidebar).
+  - `.vuepress/api-sidebar-relative.json` to be used with [multiple sidebars](https://vuepress.vuejs.org/default-theme-config/#multiple-sidebars).
 
 `.vuepress/config.json`
 
@@ -74,6 +76,21 @@ module.exports = {
 module.exports = {
   themeConfig: {
     sidebar: ['some-content', { title: 'API', children: apiSideBar }],
+  },
+};
+```
+
+```js
+const apiSideBarRelative = require('./api-sidebar-relative.json');
+
+// Multiple sidebars
+module.exports = {
+  themeConfig: {
+    sidebar: {
+      '/guide/': ['some-content'],
+      '/api/': apiSideBarRelative,
+      '/': ['other'],
+    },
   },
 };
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ The plugin also attempts to target the following platforms:
 - Adds metadata to rendered Markdown.
 - If the out directory is recognised as a docusaurus `/docs` directory, the plugin will update `website/sidebars.json` so pages are accessible in the sidebar.
 
+#### VuePress (`--platform vuepress`)
+
+- Adds metadata to rendered Markdown.
+- If the out directory is recognised as a vuepress `/docs` directory, the plugin will create `.vuepress/api-sidebar.json` so pages are accessible in the sidebar.
+
 #### Bitbucket (`--platform bitbucket`)
 
 - Support Bitbucket's internal/anchor links in rendered Markdown.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,26 @@ The plugin also attempts to target the following platforms:
 - Adds metadata to rendered Markdown.
 - If the out directory is recognised as a vuepress `/docs` directory, the plugin will create `.vuepress/api-sidebar.json` so pages are accessible in the sidebar.
 
+`.vuepress/config.json`
+
+```js
+const apiSideBar = require('./api-sidebar.json');
+
+// Without groups
+module.exports = {
+  themeConfig: {
+    sidebar: ['some-content', ...apiSideBar],
+  },
+};
+
+// With groups
+module.exports = {
+  themeConfig: {
+    sidebar: ['some-content', { title: 'API', children: apiSideBar }],
+  },
+};
+```
+
 #### Bitbucket (`--platform bitbucket`)
 
 - Support Bitbucket's internal/anchor links in rendered Markdown.

--- a/src/lib/plugin.ts
+++ b/src/lib/plugin.ts
@@ -11,6 +11,7 @@ import { MarkdownTheme } from './theme/theme';
 import { BitbucketTheme } from './theme/theme.bitbucket';
 import { DocusaurusTheme } from './theme/theme.docusaurus';
 import { GitbookTheme } from './theme/theme.gitbook';
+import { VuePressTheme } from './theme/theme.vuepress';
 
 @Component({ name: 'markdown' })
 export class MarkdownPlugin extends ConverterComponent {
@@ -21,7 +22,7 @@ export class MarkdownPlugin extends ConverterComponent {
   static location: string;
   static page: PageEvent;
   static settings: {
-    platform?: 'gitbook' | 'ducusaurus' | 'bitbucket';
+    platform?: 'gitbook' | 'ducusaurus' | 'bitbucket' | 'vuepress';
     hideSources?: boolean;
     readme?: string;
     includes?: string;
@@ -96,6 +97,9 @@ export class MarkdownPlugin extends ConverterComponent {
       }
       if (platform === 'bitbucket') {
         return new BitbucketTheme(renderer, themePath, options);
+      }
+      if (platform === 'vuepress') {
+        return new VuePressTheme(renderer, themePath, options);
       }
     }
     return new MarkdownTheme(renderer, themePath, options);

--- a/src/lib/theme/helpers/breadcrumbs.ts
+++ b/src/lib/theme/helpers/breadcrumbs.ts
@@ -4,8 +4,8 @@ import { PageEvent } from 'typedoc/dist/lib/output/events';
 import { MarkdownPlugin } from '../../plugin';
 import { DocusaurusTheme } from '../theme.docusaurus';
 import { GitbookTheme } from '../theme.gitbook';
-import { relativeUrl } from './relative-url';
 import { VuePressTheme } from '../theme.vuepress';
+import { relativeUrl } from './relative-url';
 
 export function breadcrumbs(this: PageEvent) {
   if (!isVisible()) {

--- a/src/lib/theme/helpers/breadcrumbs.ts
+++ b/src/lib/theme/helpers/breadcrumbs.ts
@@ -5,6 +5,7 @@ import { MarkdownPlugin } from '../../plugin';
 import { DocusaurusTheme } from '../theme.docusaurus';
 import { GitbookTheme } from '../theme.gitbook';
 import { relativeUrl } from './relative-url';
+import { VuePressTheme } from '../theme.vuepress';
 
 export function breadcrumbs(this: PageEvent) {
   if (!isVisible()) {
@@ -25,7 +26,11 @@ function breadcrumb(model: Reflection, md: string[]) {
 }
 
 function isVisible() {
-  if (MarkdownPlugin.theme instanceof DocusaurusTheme || MarkdownPlugin.theme instanceof GitbookTheme) {
+  if (
+    MarkdownPlugin.theme instanceof DocusaurusTheme ||
+    MarkdownPlugin.theme instanceof GitbookTheme ||
+    MarkdownPlugin.theme instanceof VuePressTheme
+  ) {
     return false;
   }
   return true;

--- a/src/lib/theme/helpers/metadata.ts
+++ b/src/lib/theme/helpers/metadata.ts
@@ -1,6 +1,7 @@
 import { PageEvent } from 'typedoc/dist/lib/output/events';
 import { MarkdownPlugin } from '../../plugin';
 import { DocusaurusTheme } from '../theme.docusaurus';
+import { VuePressTheme } from '../theme.vuepress';
 
 export function metadata(this: PageEvent) {
   if (!isVisible()) {
@@ -41,7 +42,7 @@ function getTitle(page: PageEvent) {
 }
 
 function isVisible() {
-  if (MarkdownPlugin.theme instanceof DocusaurusTheme) {
+  if (MarkdownPlugin.theme instanceof DocusaurusTheme || MarkdownPlugin.theme instanceof VuePressTheme) {
     return true;
   }
   return false;

--- a/src/lib/theme/helpers/project-title.ts
+++ b/src/lib/theme/helpers/project-title.ts
@@ -3,9 +3,9 @@ import { PageEvent } from 'typedoc/dist/lib/output/events';
 import { MarkdownPlugin } from '../../plugin';
 import { DocusaurusTheme } from '../theme.docusaurus';
 import { GitbookTheme } from '../theme.gitbook';
+import { VuePressTheme } from '../theme.vuepress';
 import { heading } from './heading';
 import { relativeUrl } from './relative-url';
-import { VuePressTheme } from '../theme.vuepress';
 
 export function projectTitle(this: PageEvent) {
   if (!isVisible()) {

--- a/src/lib/theme/helpers/project-title.ts
+++ b/src/lib/theme/helpers/project-title.ts
@@ -5,6 +5,7 @@ import { DocusaurusTheme } from '../theme.docusaurus';
 import { GitbookTheme } from '../theme.gitbook';
 import { heading } from './heading';
 import { relativeUrl } from './relative-url';
+import { VuePressTheme } from '../theme.vuepress';
 
 export function projectTitle(this: PageEvent) {
   if (!isVisible()) {
@@ -14,7 +15,11 @@ export function projectTitle(this: PageEvent) {
 }
 
 function isVisible() {
-  if (MarkdownPlugin.theme instanceof DocusaurusTheme || MarkdownPlugin.theme instanceof GitbookTheme) {
+  if (
+    MarkdownPlugin.theme instanceof DocusaurusTheme ||
+    MarkdownPlugin.theme instanceof GitbookTheme ||
+    MarkdownPlugin.theme instanceof VuePressTheme
+  ) {
     return false;
   }
   return true;

--- a/src/lib/theme/helpers/reflection-index.ts
+++ b/src/lib/theme/helpers/reflection-index.ts
@@ -1,0 +1,10 @@
+import { DeclarationReflection } from 'typedoc';
+import { MarkdownPlugin } from '../../plugin';
+import { VuePressTheme } from '../theme.vuepress';
+
+export function ifDisplayIndex(this: DeclarationReflection, options: Handlebars.HelperOptions) {
+  if (MarkdownPlugin.theme instanceof VuePressTheme) {
+    return options.inverse(this);
+  }
+  return options.fn(this);
+}

--- a/src/lib/theme/templates/reflection.hbs
+++ b/src/lib/theme/templates/reflection.hbs
@@ -82,7 +82,9 @@
 
 {{#with model}}
 
-  {{> index}}
+  {{#ifDisplayIndex}}
+    {{> index}}
+  {{/ifDisplayIndex}}
 
   {{> members}}
 

--- a/src/lib/theme/theme.vuepress.ts
+++ b/src/lib/theme/theme.vuepress.ts
@@ -3,7 +3,7 @@
  * May be used in `.vuepress/config.json` as follows:
  * @example
  * const apiSideBar = require("./api-sidebar.json");
- * // Wiyhout groups
+ * // Without groups
  * module.exports = {
  *   themeConfig: {
  *     sidebar: ["some-content", ...apiSideBar]

--- a/src/lib/theme/theme.vuepress.ts
+++ b/src/lib/theme/theme.vuepress.ts
@@ -66,8 +66,9 @@ export class VuePressTheme extends MarkdownTheme {
     if (MarkdownPlugin.project.url === this.globalsName) {
       projectUrls.push(docsRoot + 'globals');
     }
-    const packageName = MarkdownPlugin.project.packageInfo.name;
-    const navObject: any = [{ title: packageName, children: projectUrls }];
+
+    // const packageName = MarkdownPlugin.project.packageInfo.name;
+    const navObject = []; // [{ title: packageName, children: projectUrls }]
 
     this.navigation.children.forEach(rootNavigation => {
       navObject.push({

--- a/src/lib/theme/theme.vuepress.ts
+++ b/src/lib/theme/theme.vuepress.ts
@@ -1,0 +1,106 @@
+/**
+ * Creates `api-sidebar.json` in `.vuepress` directory.
+ * May be used in `.vuepress/config.json` as follows:
+ * @example
+ * const apiSideBar = require("./api-sidebar.json");
+ * // Wiyhout groups
+ * module.exports = {
+ *   themeConfig: {
+ *     sidebar: ["some-content", ...apiSideBar]
+ *   }
+ * };
+ *
+ * // With groups
+ * module.exports = {
+ *   themeConfig: {
+ *     sidebar: ["some-content", { title: "API", children: apiSideBar }]
+ *   }
+ * };
+ */
+
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { RendererEvent } from 'typedoc/dist/lib/output/events';
+import { Renderer } from 'typedoc/dist/lib/output/renderer';
+import { MarkdownPlugin } from '../plugin';
+import { MarkdownTheme } from './theme';
+
+export class VuePressTheme extends MarkdownTheme {
+  constructor(renderer: Renderer, basePath: string, options: any) {
+    super(renderer, basePath, options);
+    this.listenTo(renderer, RendererEvent.END, this.onRendererEnd, 1024);
+  }
+
+  onRendererEnd(renderer: RendererEvent) {
+    const root = this.findRoot(renderer.outputDirectory);
+    if (root === null) {
+      this.application.logger.warn(
+        `[typedoc-markdown-plugin] sidebars.json not written as could not locate VuePress root directory. In order to to implemnent sidebars.json functionality, the output directory must be a child of a 'docs' directory.`,
+      );
+      return;
+    }
+    this.writeSideBar(renderer.outputDirectory, root);
+  }
+
+  writeSideBar(outputDirectory: string, root: string) {
+    const childDirectory = outputDirectory.split(root + 'docs/')[1];
+    const docsRoot = childDirectory ? childDirectory + '/' : '';
+    const vuePressRoot = root + 'docs/.vuepress';
+    const navObject = this.getNavObject(docsRoot);
+    const sidebarPath = vuePressRoot + '/api-sidebar.json';
+
+    if (!fs.existsSync(vuePressRoot)) {
+      fs.mkdirSync(vuePressRoot);
+    }
+
+    try {
+      fs.writeFileSync(sidebarPath, JSON.stringify(navObject, null, 2));
+      this.application.logger.write(`[typedoc-plugin-markdown] sidebars.json updated at ${sidebarPath}`);
+    } catch (e) {
+      this.application.logger.write(`[typedoc-plugin-markdown] failed to update sidebars.json at ${sidebarPath}`);
+    }
+  }
+
+  getNavObject(docsRoot: string) {
+    const projectUrls = [docsRoot + this.indexName.replace('.md', '')];
+    if (MarkdownPlugin.project.url === this.globalsName) {
+      projectUrls.push(docsRoot + 'globals');
+    }
+    const packageName = MarkdownPlugin.project.packageInfo.name;
+    const navObject: any = [{ title: packageName, children: projectUrls }];
+
+    this.navigation.children.forEach(rootNavigation => {
+      navObject.push({
+        title: rootNavigation.title,
+        children: rootNavigation.children.map(item => {
+          return docsRoot + item.url.replace('.md', '');
+        }),
+      });
+    });
+    return navObject;
+  }
+
+  findRoot(outputDirectory: string) {
+    const docsName = 'docs';
+    function splitPath(dir: string) {
+      const parts = dir.split(/(\/|\\)/);
+      if (!parts.length) {
+        return parts;
+      }
+      return !parts[0].length ? parts.slice(1) : parts;
+    }
+    function testDir(parts) {
+      if (parts.length === 0) {
+        return null;
+      }
+      const p = parts.join('');
+      const itdoes = fs.existsSync(path.join(p, docsName));
+      return itdoes ? p : testDir(parts.slice(0, -1));
+    }
+    return testDir(splitPath(outputDirectory));
+  }
+
+  get indexName() {
+    return 'index.md';
+  }
+}

--- a/src/lib/theme/theme.vuepress.ts
+++ b/src/lib/theme/theme.vuepress.ts
@@ -118,6 +118,6 @@ export class VuePressTheme extends MarkdownTheme {
   }
 
   get indexName() {
-    return 'index.md';
+    return 'README.md';
   }
 }

--- a/src/lib/theme/theme.vuepress.ts
+++ b/src/lib/theme/theme.vuepress.ts
@@ -3,6 +3,8 @@
  * May be used in `.vuepress/config.json` as follows:
  * @example
  * const apiSideBar = require("./api-sidebar.json");
+ * const apiSideBarRelative = require('./api-sidebar-relative.json');
+ *
  * // Without groups
  * module.exports = {
  *   themeConfig: {
@@ -15,6 +17,17 @@
  *   themeConfig: {
  *     sidebar: ["some-content", { title: "API", children: apiSideBar }]
  *   }
+ * };
+ *
+ * // Multiple Sidebar
+ * module.exports = {
+ *   themeConfig: {
+ *     sidebar: {
+ *       '/guide/': ['some-content'],
+ *       '/api/': apiSideBarRelative,
+ *       '/': ['other'],
+ *     },
+ *   },
  * };
  */
 
@@ -48,6 +61,8 @@ export class VuePressTheme extends MarkdownTheme {
     const vuePressRoot = root + 'docs/.vuepress';
     const navObject = this.getNavObject(docsRoot);
     const sidebarPath = vuePressRoot + '/api-sidebar.json';
+    const relativeNavObject = this.getNavObject();
+    const relativeSidebarPath = vuePressRoot + '/api-sidebar-relative.json';
 
     if (!fs.existsSync(vuePressRoot)) {
       fs.mkdirSync(vuePressRoot);
@@ -55,13 +70,14 @@ export class VuePressTheme extends MarkdownTheme {
 
     try {
       fs.writeFileSync(sidebarPath, JSON.stringify(navObject, null, 2));
+      fs.writeFileSync(relativeSidebarPath, JSON.stringify(relativeNavObject, null, 2));
       this.application.logger.write(`[typedoc-plugin-markdown] sidebars.json updated at ${sidebarPath}`);
     } catch (e) {
       this.application.logger.write(`[typedoc-plugin-markdown] failed to update sidebars.json at ${sidebarPath}`);
     }
   }
 
-  getNavObject(docsRoot: string) {
+  getNavObject(docsRoot: string = '') {
     const projectUrls = [docsRoot + this.indexName.replace('.md', '')];
     if (MarkdownPlugin.project.url === this.globalsName) {
       projectUrls.push(docsRoot + 'globals');


### PR DESCRIPTION
This pull request adds VuePress support.

It could be better to not include `index` part to the created markdowns, because sidebar already has it. How can I disable that part in generated markdown files?

## Sidebar Collapsed Screenshot:
![image](https://user-images.githubusercontent.com/1497060/59681231-1274fc00-91dc-11e9-9990-51f1fdb70580.png)

## Sidebar Expanded Screenshot:
![image](https://user-images.githubusercontent.com/1497060/59681168-eeb1b600-91db-11e9-85b6-8046f2c78925.png)
