### PR TITLE
Fixed theme template

### DIFF
--- a/src/lib/theme/partials/member.sources.hbs
+++ b/src/lib/theme/partials/member.sources.hbs
@@ -22,7 +22,7 @@
 
     {{#if url}}
 
-      *Defined in [{{fileName}}:{{line}}](url)*
+      *Defined in [{{fileName}}:{{line}}]({{url}})*
 
     {{else}}
 


### PR DESCRIPTION
This fixes an issue in a template file markdown that would cause "Defined in ..." hyperlinks to point to a nonexisting page.