### PR TITLE
replace @user from title, prefer label. Fixes #64

### DIFF
--- a/src/lib/theme/helpers/metadata.ts
+++ b/src/lib/theme/helpers/metadata.ts
@@ -33,7 +33,8 @@ function getLabel(page: PageEvent) {
 
 function getTitle(page: PageEvent) {
   if (page.url === MarkdownPlugin.theme.indexName) {
-    return page.project.name;
+    // If package.json has `label`, use that, otherwise use project name. YAML parser throws if project name contains `@` like @someuser/project-name, so replace username.
+    return (page.project.packageInfo && page.project.packageInfo.label) || page.project.name.replace(/^@.+?\//, '');
   }
   if (page.url === MarkdownPlugin.theme.globalsName) {
     return 'Globals';


### PR DESCRIPTION
This PR replaces `@someuser/` from `@someuser/module-name` when used in title meta data.

Additionally, backwards compatible, if `label` field is available in `package.json`, prefers to use that, otherwise uses project name.

## Module with username

**package.json**

```
{
  name: @someuser/module-name
}
```
produces
```md
---
title: Fortibase Scrap
---
```

## Label

```
{
  name: @someuser/awesome-module
  label: AweSOME
}
```
produces
```md
---
title: AweSOME
---
```
