### PR TITLE
avoid YAML indicators in frontmatter; fixes #80

### DIFF
--- a/src/lib/theme/helpers/__snapshots__/metadata.spec.ts.snap
+++ b/src/lib/theme/helpers/__snapshots__/metadata.spec.ts.snap
@@ -2,9 +2,9 @@
 
 exports[`metadata helper should compile 1`] = `
 "---
-id: xyz
-title: xyx title
-sidebar_label: xyx title
+id: 'xyz'
+title: 'xyx\\\\'s title'
+sidebar_label: 'xyx\\\\'s title'
 ---
 "
 `;

--- a/src/lib/theme/helpers/metadata.spec.ts
+++ b/src/lib/theme/helpers/metadata.spec.ts
@@ -11,7 +11,7 @@ describe(`metadata helper`, () => {
   test(`should compile`, () => {
     MarkdownPlugin.theme = new DocusaurusTheme({} as Renderer, '/', {});
     MarkdownPlugin.theme.navigationTitlesMap = {
-      ['xyz.md']: 'xyx title',
+      ['xyz.md']: `xyx's title`,
     };
     MarkdownPlugin.project = {
       packageInfo: { name: 'typedoc-test' },

--- a/src/lib/theme/helpers/metadata.ts
+++ b/src/lib/theme/helpers/metadata.ts
@@ -9,37 +9,45 @@ export function metadata(this: PageEvent) {
   }
 
   const md = `---
-id: ${getId(this)}
-title: ${getTitle(this)}
-sidebar_label: ${getLabel(this)}
+id: '${getId(this)}'
+title: '${getTitle(this)}'
+sidebar_label: '${getLabel(this)}'
 ---\n`;
   return md;
 }
 
+function escapeYAMLString(str: string = '') {
+  return str.replace(/([^\\])'/g, '$1\\\'');
+}
+
 function getId(page: PageEvent) {
   const urlSplit = page.url.split('/');
-  return urlSplit[urlSplit.length - 1].replace('.md', '');
+  return escapeYAMLString(urlSplit[urlSplit.length - 1].replace('.md', ''));
 }
 
 function getLabel(page: PageEvent) {
+  let label: string;
   if (page.url === MarkdownPlugin.theme.indexName) {
-    return MarkdownPlugin.settings.readme === 'none' ? 'Globals' : 'README';
+    label = MarkdownPlugin.settings.readme === 'none' ? 'Globals' : 'README';
+  } else if (page.url === MarkdownPlugin.theme.globalsName) {
+    label = 'Globals';
+  } else {
+    label = getTitle(page);
   }
-  if (page.url === MarkdownPlugin.theme.globalsName) {
-    return 'Globals';
-  }
-  return getTitle(page);
+  return escapeYAMLString(label);
 }
 
 function getTitle(page: PageEvent) {
+  let title: string;
   if (page.url === MarkdownPlugin.theme.indexName) {
-    // If package.json has `label`, use that, otherwise use project name. YAML parser throws if project name contains `@` like @someuser/project-name, so replace username.
-    return (page.project.packageInfo && page.project.packageInfo.label) || page.project.name.replace(/^@.+?\//, '');
+    // If package.json has `label`, use that, otherwise use project name.
+    title = (page.project.packageInfo && page.project.packageInfo.label) || page.project.name;
+  } else if (page.url === MarkdownPlugin.theme.globalsName) {
+    title = 'Globals';
+  } else {
+    title = MarkdownPlugin.theme.navigationTitlesMap[page.url];
   }
-  if (page.url === MarkdownPlugin.theme.globalsName) {
-    return 'Globals';
-  }
-  return MarkdownPlugin.theme.navigationTitlesMap[page.url];
+  return escapeYAMLString(title);
 }
 
 function isVisible() {


### PR DESCRIPTION
See #82 for original PR; this version of the change avoids the lookbehind in the regexp.  