### PR TITLE
Do not use quotes for ID in the top matter

### DIFF
--- a/src/lib/theme/helpers/__snapshots__/metadata.spec.ts.snap
+++ b/src/lib/theme/helpers/__snapshots__/metadata.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`metadata helper should compile 1`] = `
 "---
-id: 'xyz'
+id: xyz
 title: 'xyx\\\\'s title'
 sidebar_label: 'xyx\\\\'s title'
 ---

--- a/src/lib/theme/helpers/metadata.ts
+++ b/src/lib/theme/helpers/metadata.ts
@@ -9,7 +9,7 @@ export function metadata(this: PageEvent) {
   }
 
   const md = `---
-id: '${getId(this)}'
+id: ${getId(this)}
 title: '${getTitle(this)}'
 sidebar_label: '${getLabel(this)}'
 ---\n`;
@@ -22,7 +22,7 @@ function escapeYAMLString(str: string = '') {
 
 function getId(page: PageEvent) {
   const urlSplit = page.url.split('/');
-  return escapeYAMLString(urlSplit[urlSplit.length - 1].replace('.md', ''));
+  return urlSplit[urlSplit.length - 1].replace('.md', '');
 }
 
 function getLabel(page: PageEvent) {


### PR DESCRIPTION
If the ID in the top matter has quotes around it, Docusaurus will include those in the filenames it generates. However, I'm not quite sure whether this solution (just removing them) is desirable; perhaps using quotes is necessary for one of the other platforms?

Fixes #25.