### PR TITLE
Do not enclose Front Matter strings with quotes

### DIFF
--- a/src/lib/theme/helpers/__snapshots__/metadata.spec.ts.snap
+++ b/src/lib/theme/helpers/__snapshots__/metadata.spec.ts.snap
@@ -3,8 +3,17 @@
 exports[`metadata helper should compile 1`] = `
 "---
 id: xyz
-title: 'xyx\\\\'s title'
-sidebar_label: 'xyx\\\\'s title'
+title: xyx's title
+sidebar_label: xyx's title
+---
+"
+`;
+
+exports[`metadata helper should escape strings that start with an @ 1`] = `
+"---
+id: xyz
+title: '@scoped/package\\\\'s title'
+sidebar_label: '@scoped/package\\\\'s title'
 ---
 "
 `;

--- a/src/lib/theme/helpers/metadata.spec.ts
+++ b/src/lib/theme/helpers/metadata.spec.ts
@@ -24,4 +24,21 @@ describe(`metadata helper`, () => {
     const result = metadata.call(data);
     expect(result).toMatchSnapshot();
   });
+
+  test(`should escape strings that start with an @`, () => {
+    MarkdownPlugin.theme = new DocusaurusTheme({} as Renderer, '/', {});
+    MarkdownPlugin.theme.navigationTitlesMap = {
+      ['xyz.md']: `@scoped/package's title`,
+    };
+    MarkdownPlugin.project = {
+      packageInfo: { name: 'typedoc-test' },
+    } as ProjectReflection;
+    MarkdownPlugin.settings = { readme: 'none' };
+    const data = {
+      url: 'xyz.md',
+      model: getFixture(Fixture.Variable).children[0],
+    };
+    const result = metadata.call(data);
+    expect(result).toMatchSnapshot();
+  });
 });

--- a/src/lib/theme/helpers/metadata.ts
+++ b/src/lib/theme/helpers/metadata.ts
@@ -10,19 +10,27 @@ export function metadata(this: PageEvent) {
 
   const md = `---
 id: ${getId(this)}
-title: '${getTitle(this)}'
-sidebar_label: '${getLabel(this)}'
+title: ${getTitle(this)}
+sidebar_label: ${getLabel(this)}
 ---\n`;
   return md;
 }
 
-function escapeYAMLString(str: string = '') {
-  return str.replace(/([^\\])'/g, '$1\\\'');
+/**
+ * Enclose strings in quotes (and escape included quotes) if it's a Yaml indicator
+ *
+ * See https://github.com/tgreyuk/typedoc-plugin-markdown/issues/80 and
+ * https://github.com/tgreyuk/typedoc-plugin-markdown/issues/86.
+ */
+function escapeYAMLStringIfNecessary(str: string = '') {
+  return str.charAt(0) === '@'
+    ? `'${str.replace(/([^\\])'/g, '$1\\\'')}'`
+    : str;
 }
 
 function getId(page: PageEvent) {
   const urlSplit = page.url.split('/');
-  return urlSplit[urlSplit.length - 1].replace('.md', '');
+  return escapeYAMLStringIfNecessary(urlSplit[urlSplit.length - 1].replace('.md', ''));
 }
 
 function getLabel(page: PageEvent) {
@@ -34,7 +42,7 @@ function getLabel(page: PageEvent) {
   } else {
     label = getTitle(page);
   }
-  return escapeYAMLString(label);
+  return escapeYAMLStringIfNecessary(label);
 }
 
 function getTitle(page: PageEvent) {
@@ -47,7 +55,7 @@ function getTitle(page: PageEvent) {
   } else {
     title = MarkdownPlugin.theme.navigationTitlesMap[page.url];
   }
-  return escapeYAMLString(title);
+  return escapeYAMLStringIfNecessary(title);
 }
 
 function isVisible() {


### PR DESCRIPTION
Building on #87, this also removes the quotes around other entries in the front matter, which currently results in quotes around the titles for me in Docusaurus:

![image](https://user-images.githubusercontent.com/4251/64099596-f5c37b80-cd69-11e9-9732-ebcaad6f943c.png)

However, that did mean `escapeYAMLString` was no longer relevant, so I've removed it.  Still somewhat unsure about whether it was not added to support some other use case, though...