### PR TITLE
Enclose strings in double quotes

### DIFF
--- a/src/lib/theme/helpers/__snapshots__/metadata.spec.ts.snap
+++ b/src/lib/theme/helpers/__snapshots__/metadata.spec.ts.snap
@@ -2,18 +2,18 @@
 
 exports[`metadata helper should compile 1`] = `
 "---
-id: xyz
-title: xyx's title
-sidebar_label: xyx's title
+id: \\"xyz\\"
+title: \\"xyx's \\\\\\"quoted\\\\\\" title\\"
+sidebar_label: \\"\\"xyx's \\\\\\"quoted\\\\\\" title\\\\\\"\\"
 ---
 "
 `;
 
 exports[`metadata helper should escape strings that start with an @ 1`] = `
 "---
-id: xyz
-title: '@scoped/package\\\\'s title'
-sidebar_label: '@scoped/package\\\\'s title'
+id: \\"xyz\\"
+title: \\"@scoped/package's \\\\\\"quoted\\\\\\" title\\"
+sidebar_label: \\"\\"@scoped/package's \\\\\\"quoted\\\\\\" title\\\\\\"\\"
 ---
 "
 `;

--- a/src/lib/theme/helpers/metadata.spec.ts
+++ b/src/lib/theme/helpers/metadata.spec.ts
@@ -11,7 +11,7 @@ describe(`metadata helper`, () => {
   test(`should compile`, () => {
     MarkdownPlugin.theme = new DocusaurusTheme({} as Renderer, '/', {});
     MarkdownPlugin.theme.navigationTitlesMap = {
-      ['xyz.md']: `xyx's title`,
+      ['xyz.md']: `xyx's "quoted" title`,
     };
     MarkdownPlugin.project = {
       packageInfo: { name: 'typedoc-test' },
@@ -28,7 +28,7 @@ describe(`metadata helper`, () => {
   test(`should escape strings that start with an @`, () => {
     MarkdownPlugin.theme = new DocusaurusTheme({} as Renderer, '/', {});
     MarkdownPlugin.theme.navigationTitlesMap = {
-      ['xyz.md']: `@scoped/package's title`,
+      ['xyz.md']: `@scoped/package's "quoted" title`,
     };
     MarkdownPlugin.project = {
       packageInfo: { name: 'typedoc-test' },

--- a/src/lib/theme/helpers/metadata.ts
+++ b/src/lib/theme/helpers/metadata.ts
@@ -17,20 +17,18 @@ sidebar_label: ${getLabel(this)}
 }
 
 /**
- * Enclose strings in quotes (and escape included quotes) if it's a Yaml indicator
+ * Enclose strings in quotes (and escape included quotes) in case it's a Yaml indicator
  *
  * See https://github.com/tgreyuk/typedoc-plugin-markdown/issues/80 and
  * https://github.com/tgreyuk/typedoc-plugin-markdown/issues/86.
  */
-function escapeYAMLStringIfNecessary(str: string = '') {
-  return str.charAt(0) === '@'
-    ? `'${str.replace(/([^\\])'/g, '$1\\\'')}'`
-    : str;
+function toYamlString(str: string = '') {
+  return `"${str.replace(/([^\\])"/g, '$1\\"')}"`;
 }
 
 function getId(page: PageEvent) {
   const urlSplit = page.url.split('/');
-  return escapeYAMLStringIfNecessary(urlSplit[urlSplit.length - 1].replace('.md', ''));
+  return toYamlString(urlSplit[urlSplit.length - 1].replace('.md', ''));
 }
 
 function getLabel(page: PageEvent) {
@@ -42,7 +40,7 @@ function getLabel(page: PageEvent) {
   } else {
     label = getTitle(page);
   }
-  return escapeYAMLStringIfNecessary(label);
+  return toYamlString(label);
 }
 
 function getTitle(page: PageEvent) {
@@ -55,7 +53,7 @@ function getTitle(page: PageEvent) {
   } else {
     title = MarkdownPlugin.theme.navigationTitlesMap[page.url];
   }
-  return escapeYAMLStringIfNecessary(title);
+  return toYamlString(title);
 }
 
 function isVisible() {


### PR DESCRIPTION
As discussed in https://github.com/tgreyuk/typedoc-plugin-markdown/pull/88#issuecomment-527068036, this encloses all strings in Yaml front matter in double quotes.