### PR TITLE
Don't quote label twice

### DIFF
--- a/src/lib/theme/helpers/metadata.ts
+++ b/src/lib/theme/helpers/metadata.ts
@@ -41,7 +41,7 @@ function getLabel(page: PageEvent) {
   } else {
     label = getTitle(page);
   }
-  return toYamlString(label);
+  return label;
 }
 
 function getTitle(page: PageEvent) {


### PR DESCRIPTION
A dynamic label comes from `getTitle` where it's already being quoted once, resulting in double quotes:

```
id: "device"
title: "Device"
sidebar_label: ""Device\""
```

This fix will produce:

```
id: "device"
title: "Device"
sidebar_label: "Device"
```