### PR TITLE
Fix: sidebars.js is in the website root

### DIFF
--- a/src/subthemes/docusaurus2/theme.ts
+++ b/src/subthemes/docusaurus2/theme.ts
@@ -32,9 +32,9 @@ export default class Docusaurus2Theme extends MarkdownTheme {
   writeSideBar(renderer: RendererEvent, docusarusRoot: string) {
     const childDirectory = renderer.outputDirectory.split(docusarusRoot + 'docs/')[1];
     const docsRoot = childDirectory ? childDirectory + '/' : '';
-    const websitePath = docusarusRoot + 'website';
+    const websitePath = docusarusRoot;
     const navObject = this.getNavObject(renderer, docsRoot);
-    const sidebarPath = websitePath + '/' + this.sidebarName;
+    const sidebarPath = websitePath + this.sidebarName;
     let jsonContent: any;
     if (!fs.existsSync(sidebarPath)) {
       if (!fs.existsSync(websitePath)) {


### PR DESCRIPTION
(I didn't really know how to properly test this, so consider this a _somewhat_ more constructive issue report.)

It might have been different in the past because Docusaurus 2 is still in Alpha, but when I just generated a new documentation website using the `classic` Docusaurus 2 preset, it did _not_ create a separate `/website` directory inside the documentation site root in which `sidebars.js` was located. Instead, `sidebars.js` was located at the root of the documentation site.

This means that the Markdown plugin for Typedoc is creating a new `/website/sidebars.js` file for me, rather than updating the existing `/sidebars.js`.