### PR TITLE
Escape angle brackets

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -420,6 +420,8 @@ export default class MarkdownTheme extends Theme {
       contents
         .replace(/[\r\n]{3,}/g, '\n\n')
         .replace(/!spaces/g, '')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
         .replace(/^\s+|\s+$/g, '') + '\n'
     );
   }


### PR DESCRIPTION
Docusaurus 2 renders not just Markdown, but MDX, i.e. rendering Markdown with embedded JSX components. Unfortunately, it is not as forgiving as regular Markdown is of random non-HTML angle brackets - like in the case of generics.

This means that when I'm trying to render the generated Markdown, Docusaurus 2 throws the following error:

> SyntaxError: unknown: Expected corresponding JSX closing tag for <GenericName>

Specifically, this was for a type declaration like this:

```
type TypeAlias<GenericName extends ParentGeneric> = (
  param: SomeParentType
) => param is SomeChildType<GenericName>
```

Now, replacing angle brackets with their HTML Entities globally solved my issue, but I'm not sure whether it's the right approach - specifically, whether it'd be possible/desirable to do something like this _just_ for the Docusaurus 2 subtheme. Additionally, I wasn't sure how to write a test for it.

If you'd like me to try a different approach, do let me know. (And if this shouldn't be fixed here, that's your perogative as well of course :) )