### PR TITLE
Update inputFiles example

### DIFF
--- a/packages/docusaurus-plugin-typedoc/README.md
+++ b/packages/docusaurus-plugin-typedoc/README.md
@@ -31,7 +31,7 @@ module.exports = {
       // plugin options
       {
         // list of input files relative to project (required).
-        inputFiles: ['../../src/'],
+        inputFiles: ['../src/'],
 
         // docs directory relative to the site directory (defaults to docs).
         docsRoot: 'docs',


### PR DESCRIPTION
Usually, the docusaurus root is in the `website` folder, so one level up is enough for most of the cases.