### PR TITLE
Option to output all reflections into seperate files (#154)

### DIFF
--- a/packages/typedoc-plugin-markdown/src/components/front-matter.component.ts
+++ b/packages/typedoc-plugin-markdown/src/components/front-matter.component.ts
@@ -1,11 +1,9 @@
 import * as path from 'path';
-
 import {
   Component,
   ContextAwareRendererComponent,
 } from 'typedoc/dist/lib/output/components';
 import { PageEvent } from 'typedoc/dist/lib/output/events';
-
 import { reflectionTitle } from '../resources/helpers/reflection-title';
 
 @Component({ name: 'frontmatter' })
@@ -55,7 +53,7 @@ ${Object.entries(yamlItems)
   }
 
   getTitle(page: PageEvent) {
-    return reflectionTitle.call(page, false);
+    return reflectionTitle.call(page, false, false);
   }
 
   // prettier-ignore

--- a/packages/typedoc-plugin-markdown/src/index.ts
+++ b/packages/typedoc-plugin-markdown/src/index.ts
@@ -1,6 +1,5 @@
 import { Application } from 'typedoc/dist/lib/application';
 import { ParameterType } from 'typedoc/dist/lib/utils/options/declaration';
-
 import { MarkdownPlugin } from './plugin';
 
 export = (PluginHost: Application) => {
@@ -42,6 +41,14 @@ export = (PluginHost: Application) => {
     help:
       '[Markdown Plugin] Use HTML named anchors as fragment identifiers for engines that do not automatically assign header ids. Should be set for Bitbucket Server docs.',
     name: 'namedAnchors',
+    type: ParameterType.Boolean,
+    defaultValue: false,
+  });
+
+  app.options.addDeclaration({
+    help:
+      '[Markdown Plugin] Output all reflections into seperate output files.',
+    name: 'allReflectionsHaveOwnDocument',
     type: ParameterType.Boolean,
     defaultValue: false,
   });

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/breadcrumbs.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/breadcrumbs.ts
@@ -1,7 +1,7 @@
 import { Reflection } from 'typedoc';
 import { PageEvent } from 'typedoc/dist/lib/output/events';
-
 import MarkdownTheme from '../../theme';
+import { escape } from './escape';
 
 export function breadcrumbs(this: PageEvent) {
   const breadcrumbs: string[] = [];
@@ -22,10 +22,10 @@ function breadcrumb(page: PageEvent, model: Reflection, md: string[]) {
     if (model.url) {
       md.push(
         page.url === model.url
-          ? `${model.name}`
-          : `[${model.name}](${MarkdownTheme.HANDLEBARS.helpers.relativeURL(
-              model.url,
-            )})`,
+          ? `${escape(model.name)}`
+          : `[${escape(
+              model.name,
+            )}](${MarkdownTheme.HANDLEBARS.helpers.relativeURL(model.url)})`,
       );
     }
   }

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/reflection-title.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/reflection-title.ts
@@ -1,6 +1,11 @@
 import { PageEvent } from 'typedoc/dist/lib/output/events';
+import { escape } from './escape';
 
-export function reflectionTitle(this: PageEvent, withParams: boolean) {
+export function reflectionTitle(
+  this: PageEvent,
+  withParams: boolean,
+  shouldEscape = true,
+) {
   const title: string[] = [];
   if (this.model.kindString) {
     title.push(`${this.model.kindString}: `);
@@ -12,5 +17,5 @@ export function reflectionTitle(this: PageEvent, withParams: boolean) {
       .join(', ');
     title.push(`\\<**${typeParameters}**>`);
   }
-  return title.join('');
+  return shouldEscape ? escape(title.join('')) : title.join('');
 }

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/reflection-title.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/reflection-title.ts
@@ -10,12 +10,12 @@ export function reflectionTitle(
   if (this.model.kindString) {
     title.push(`${this.model.kindString}: `);
   }
-  title.push(this.model.name);
+  title.push(shouldEscape ? escape(this.model.name) : this.model.name);
   if (withParams && this.model.typeParameters) {
     const typeParameters = this.model.typeParameters
       .map((typeParameter) => typeParameter.name)
       .join(', ');
     title.push(`\\<**${typeParameters}**>`);
   }
-  return shouldEscape ? escape(title.join('')) : title.join('');
+  return title.join('');
 }

--- a/packages/typedoc-plugin-markdown/src/resources/partials/member.hbs
+++ b/packages/typedoc-plugin-markdown/src/resources/partials/member.hbs
@@ -1,8 +1,12 @@
+{{#unless hasOwnDocument}}
+
 {{#if name}}
 
 ### {{#ifNamedAnchors}}<a id="{{anchor}}" name="{{this.anchor}}"></a> {{/ifNamedAnchors}}{{ escape name }}
 
 {{/if}}
+
+{{/unless}}
 
 {{#if signatures}}
 
@@ -35,7 +39,7 @@
 {{/if}}
 
 {{#unless @last}}
-{{#unless hideHr}}
+{{#unless hasOwnDocument}}
 ___
 {{/unless}}
 {{/unless}}

--- a/packages/typedoc-plugin-markdown/src/resources/templates/reflection.member.hbs
+++ b/packages/typedoc-plugin-markdown/src/resources/templates/reflection.member.hbs
@@ -1,0 +1,7 @@
+{{> header showTitle=true}}
+
+{{#with model}}
+
+{{> member}}
+
+{{/with}}

--- a/packages/typedoc-plugin-markdown/src/theme.ts
+++ b/packages/typedoc-plugin-markdown/src/theme.ts
@@ -362,25 +362,25 @@ export default class MarkdownTheme extends Theme {
         ? [
             {
               kind: [ReflectionKind.Variable],
-              isLeaf: false,
+              isLeaf: true,
               directory: 'variables',
               template: 'reflection.member.hbs',
             },
             {
               kind: [ReflectionKind.TypeAlias],
-              isLeaf: false,
+              isLeaf: true,
               directory: 'types',
               template: 'reflection.member.hbs',
             },
             {
               kind: [ReflectionKind.Function],
-              isLeaf: false,
+              isLeaf: true,
               directory: 'functions',
               template: 'reflection.member.hbs',
             },
             {
               kind: [ReflectionKind.ObjectLiteral],
-              isLeaf: false,
+              isLeaf: true,
               directory: 'literals',
               template: 'reflection.member.hbs',
             },

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/theme.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/theme.spec.ts.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Theme: (getUrls) should getUrls with 'allReflectionsHaveOwnDocument' set 1`] = `
+Array [
+  "globals.md",
+  "README.md",
+  "modules/_theme_.md",
+  "modules/_theme_.namespacea.md",
+  "modules/_theme_.namespaceb.md",
+  "enums/_theme_.enumitema.md",
+  "enums/_theme_.enumitemb.md",
+  "classes/_theme_.classitema.md",
+  "classes/_theme_.classitemb.md",
+  "interfaces/_theme_.interfaceitema.md",
+  "interfaces/_theme_.interfaceitema.md#prop",
+  "interfaces/_theme_.interfaceitemb.md",
+  "interfaces/_theme_.interfaceitemb.md#prop",
+  "variables/_theme_.declarationitema.md",
+  "variables/_theme_.declarationitemb.md",
+  "functions/_theme_.functionitema.md",
+  "functions/_theme_.functionitemb.md",
+]
+`;
+
 exports[`Theme: (getUrls) should getUrls with readme 'none' 1`] = `
 Array [
   "README.md",

--- a/packages/typedoc-plugin-markdown/test/specs/theme.spec.ts
+++ b/packages/typedoc-plugin-markdown/test/specs/theme.spec.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs';
-
 import { TestApp } from '../test-app';
 
 describe(`Theme:`, () => {
@@ -12,6 +11,12 @@ describe(`Theme:`, () => {
   describe(`(getUrls)`, () => {
     test(`should getUrls'`, () => {
       testApp.bootstrap();
+      const urlMappings = testApp.theme.getUrls(testApp.project);
+      expect(TestApp.getExpectedUrls(urlMappings)).toMatchSnapshot();
+    });
+
+    test(`should getUrls with 'allReflectionsHaveOwnDocument' set`, () => {
+      testApp.bootstrap({ allReflectionsHaveOwnDocument: true });
       const urlMappings = testApp.theme.getUrls(testApp.project);
       expect(TestApp.getExpectedUrls(urlMappings)).toMatchSnapshot();
     });


### PR DESCRIPTION
@jsamr this is a continuation of #154 .

Basically to get this working I have created another template. This could all be handled by custom theme implementation, however I thought this could be a useful pattern to introduce into the library. What do you think about the option `allReflectionsHaveOwnDocument` which will force a distinct output file for all reflections/members? This works quite nicely with the docusaurus sidebar. Let me know what you think.