### PR TITLE
don't escape characters in markdown `code` blocks

### DIFF
--- a/packages/typedoc-plugin-markdown/src/resources/helpers/property-table.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/property-table.ts
@@ -36,7 +36,7 @@ export function propertyTable(
         ? property.name === '`'
           ? '`'
           : escape(getName(property))
-        : `\`${escape(getName(property))}\``;
+        : `\`${getName(property).replace(/`/g, '\\`')}\``;
     nameCol.push(name);
     row.push(nameCol.join(' '));
 

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/declarations.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/declarations.spec.ts.snap
@@ -103,3 +103,17 @@ Name | Type |
 \`valueZ\` | string |
 "
 `;
+
+exports[`Reflections: should not escape charcters within markdown code 1`] = `
+"Ƭ  **SpecialCharacters**: { this_prop_has_underscores: number ; this|prop|has|the|pipe|character: string  }
+
+[partial: member.sources]
+
+#### Type declaration:
+
+Name | Type |
+------ | ------ |
+\`this_prop_has_underscores\` | number |
+\`this|prop|has|the|pipe|character\` | string |
+"
+`;

--- a/packages/typedoc-plugin-markdown/test/specs/declarations.spec.ts
+++ b/packages/typedoc-plugin-markdown/test/specs/declarations.spec.ts
@@ -87,6 +87,15 @@ describe(`Reflections:`, () => {
     ).toMatchSnapshot();
   });
 
+  test(`should not escape charcters within markdown code`, () => {
+    expect(
+      TestApp.compileTemplate(
+        template,
+        testApp.findReflection('SpecialCharacters'),
+      ),
+    ).toMatchSnapshot();
+  });
+
   test(`should compile enum delcaration`, () => {
     expect(
       TestApp.compileTemplate(

--- a/packages/typedoc-plugin-markdown/test/stubs/src/declarations.ts
+++ b/packages/typedoc-plugin-markdown/test/stubs/src/declarations.ts
@@ -79,6 +79,11 @@ export const __DOUBLE_UNDERSCORES_DECLARATION__ = Symbol.for('__type__');
 
 export type AnyFunctionType<A = any> = (...input: any[]) => A;
 
+export type SpecialCharacters = {
+  this_prop_has_underscores: number;
+  'this|prop|has|the|pipe|character': string;
+};
+
 export enum EnumDeclarations {
   Up = 'UP',
   Down = 'DOWN',


### PR DESCRIPTION
There's a bug that if a property of a type definition has `_` or `|` in it, it will be escaped with a `\`. But because these are rendered within markdown `code` tags, you don't need to escape anything except ` (backtick)

Added tests to confirm that this works