### PR TITLE
fix: Override section of methods overriding external methods

### DIFF
--- a/packages/typedoc-plugin-markdown/src/resources/helpers/type-and-parent.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/type-and-parent.ts
@@ -4,50 +4,58 @@ import { ArrayType, ReferenceType } from 'typedoc/dist/lib/models/types';
 import MarkdownTheme from '../../theme';
 
 export function typeAndParent(this: ArrayType | ReferenceType) {
-  if (this instanceof ReferenceType && this.reflection) {
-    const md: string[] = [];
-    const parentReflection = this.reflection.parent;
-    if (this.reflection instanceof SignatureReflection) {
-      if (
-        parentReflection &&
-        parentReflection.parent &&
-        parentReflection.parent.url
-      ) {
-        md.push(
-          `[${
-            parentReflection.parent.name
-          }](${MarkdownTheme.HANDLEBARS.helpers.relativeURL(
-            parentReflection.parent.url,
-          )})`,
-        );
-      } else if (parentReflection && parentReflection.parent) {
-        md.push(parentReflection.parent.name);
-      }
+  if (this) {
+    if ("elementType" in this) {
+      return typeAndParent.call(this.elementType) + '[]';
     } else {
-      if (parentReflection && parentReflection.url) {
-        md.push(
-          `[${
-            parentReflection.name
-          }](${MarkdownTheme.HANDLEBARS.helpers.relativeURL(
-            parentReflection.url,
-          )})`,
-        );
-      } else if (parentReflection) {
-        md.push(parentReflection.name);
-      }
-      if (this.reflection.url) {
-        md.push(
-          `[${
-            this.reflection.name
-          }](${MarkdownTheme.HANDLEBARS.helpers.relativeURL(
-            this.reflection.url,
-          )})`,
-        );
+      if (this.reflection) {
+        const md: string[] = [];
+        const parentReflection = this.reflection.parent;
+        if (this.reflection instanceof SignatureReflection) {
+          if (
+            parentReflection &&
+            parentReflection.parent &&
+            parentReflection.parent.url
+          ) {
+            md.push(
+              `[${
+                parentReflection.parent.name
+              }](${MarkdownTheme.HANDLEBARS.helpers.relativeURL(
+                parentReflection.parent.url,
+              )})`,
+            );
+          } else if (parentReflection && parentReflection.parent) {
+            md.push(parentReflection.parent.name);
+          }
+        } else {
+          if (parentReflection && parentReflection.url) {
+            md.push(
+              `[${
+                parentReflection.name
+              }](${MarkdownTheme.HANDLEBARS.helpers.relativeURL(
+                parentReflection.url,
+              )})`,
+            );
+          } else if (parentReflection) {
+            md.push(parentReflection.name);
+          }
+          if (this.reflection.url) {
+            md.push(
+              `[${
+                this.reflection.name
+              }](${MarkdownTheme.HANDLEBARS.helpers.relativeURL(
+                this.reflection.url,
+              )})`,
+            );
+          } else {
+            md.push(this.reflection.name);
+          }
+        }
+        return md.join('.');
       } else {
-        md.push(this.reflection.name);
+        return this.toString();
       }
     }
-    return md.join('.');
   }
   return 'void';
 }


### PR DESCRIPTION
Hi,

typedoc-plugin-markdown v3.6.0 seems like printing `Overrides: void` for all the methods which override methods of classes from external node modules. The following is a sample of the typedoc-plugin-markdown outputs of the method `Sample#once`:

```
▸ **once**(`event`: *string*, `handler`: Function, `context?`: *any*): [*Sample*](sample.md)

Overrides: void
```

Because `Sample#once` overrids `EventEmitter#once` from the external node module `eventemitter3`, `EventEmitter.once` is expected instead of `void`.

This PR is to fix this. I tried to replicate the `typeAndParent` from the `typedoc-default-themes`.

https://github.com/TypeStrong/typedoc-default-themes/blob/master/src/default/partials/typeAndParent.hbs