### PR TITLE
Feature: Docusaurus 'Exports' sidebar label

### DIFF
--- a/packages/docusaurus-plugin-typedoc/src/front-matter.ts
+++ b/packages/docusaurus-plugin-typedoc/src/front-matter.ts
@@ -23,8 +23,8 @@ export class FrontMatterComponent extends RendererComponent {
   readmeTitle!: string;
   @BindOption('entryDocument')
   entryDocument!: string;
-  @BindOption('allReflectionsHaveOwnDocument')
-  allReflectionsHaveOwnDocument!: boolean;
+  @BindOption('entryPoints')
+  entryPoints!: string[];
 
   globalsFile = 'modules.md';
 
@@ -58,7 +58,7 @@ export class FrontMatterComponent extends RendererComponent {
     if (sidebarPosition) {
       items = { ...items, sidebar_position: parseFloat(sidebarPosition) };
     }
-    if (page.url === page.project.url && this.allReflectionsHaveOwnDocument) {
+    if (page.url === page.project.url && this.entryPoints.length > 1) {
       items = { ...items, hide_table_of_contents: true };
     }
     return {
@@ -68,15 +68,20 @@ export class FrontMatterComponent extends RendererComponent {
   }
 
   getSidebarLabel(page: PageEvent) {
+    const indexLabel =
+      this.sidebar.indexLabel ||
+      (this.entryPoints.length > 1 ? 'Table of contents' : 'Exports');
+
     if (page.url === this.entryDocument) {
       return page.url === page.project.url
-        ? this.sidebar.indexLabel
+        ? indexLabel
         : this.sidebar.readmeLabel;
     }
 
     if (page.url === this.globalsFile) {
-      return this.sidebar.indexLabel;
+      return indexLabel;
     }
+
     return this.sidebar.fullNames ? page.model.getFullName() : page.model.name;
   }
 

--- a/packages/docusaurus-plugin-typedoc/src/options.ts
+++ b/packages/docusaurus-plugin-typedoc/src/options.ts
@@ -13,7 +13,7 @@ const DEFAULT_PLUGIN_OPTIONS: PluginOptions = {
     fullNames: false,
     sidebarFile: 'typedoc-sidebar.js',
     categoryLabel: 'API',
-    indexLabel: 'Table of contents',
+    indexLabel: undefined,
     readmeLabel: 'Readme',
     position: null,
   },

--- a/packages/docusaurus-plugin-typedoc/test/specs/__snapshots__/front-matter.spec.ts.snap
+++ b/packages/docusaurus-plugin-typedoc/test/specs/__snapshots__/front-matter.spec.ts.snap
@@ -6,6 +6,7 @@ id: \\"modules\\"
 title: \\"test-project-name\\"
 sidebar_label: \\"Custom index label\\"
 sidebar_position: 0.5
+hide_table_of_contents: true
 custom_edit_url: null
 ---
 
@@ -18,6 +19,7 @@ id: \\"modules\\"
 title: \\"test-project-name\\"
 sidebar_label: \\"Table of contents\\"
 sidebar_position: 0.5
+hide_table_of_contents: true
 custom_edit_url: null
 ---
 
@@ -31,6 +33,7 @@ title: \\"test-project-name\\"
 slug: \\"/api\\"
 sidebar_label: \\"Table of contents\\"
 sidebar_position: 0.5
+hide_table_of_contents: true
 custom_edit_url: null
 ---
 
@@ -57,6 +60,19 @@ title: \\"test-project-name\\"
 slug: \\"/api\\"
 sidebar_label: \\"Readme\\"
 sidebar_position: 0
+custom_edit_url: null
+---
+
+CONTENTS"
+`;
+
+exports[`FrontMatter: (readme) should set default index page with exports 1`] = `
+"---
+id: \\"index\\"
+title: \\"test-project-name\\"
+slug: \\"/api\\"
+sidebar_label: \\"Exports\\"
+sidebar_position: 0.5
 custom_edit_url: null
 ---
 

--- a/packages/docusaurus-plugin-typedoc/test/specs/__snapshots__/options.spec.ts.snap
+++ b/packages/docusaurus-plugin-typedoc/test/specs/__snapshots__/options.spec.ts.snap
@@ -34,7 +34,7 @@ Object {
   "sidebar": Object {
     "categoryLabel": "API",
     "fullNames": false,
-    "indexLabel": "Table of contents",
+    "indexLabel": undefined,
     "position": null,
     "readmeLabel": "Readme",
     "sidebarFile": "typedoc-sidebar.js",

--- a/packages/docusaurus-plugin-typedoc/test/specs/front-matter.spec.ts
+++ b/packages/docusaurus-plugin-typedoc/test/specs/front-matter.spec.ts
@@ -7,17 +7,20 @@ import { FrontMatterComponent } from '../../dist/front-matter';
 import { bootstrap } from '../../dist/render';
 import { PluginOptions } from '../../dist/types';
 
-async function generate(opts = {}) {
+async function generate(
+  opts = {},
+  entryPoints = [
+    '../typedoc-plugin-markdown/test/stubs/src/theme.ts',
+    '../typedoc-plugin-markdown/test/stubs/src/frontmatter.ts',
+  ],
+) {
   const app = new Application();
 
   MarkdownPlugin(app);
 
   bootstrap(app, {
     ...opts,
-    entryPoints: [
-      '../typedoc-plugin-markdown/test/stubs/src/theme.ts',
-      '../typedoc-plugin-markdown/test/stubs/src/frontmatter.ts',
-    ],
+    entryPoints,
     tsconfig: '../typedoc-plugin-markdown/test/stubs/tsconfig.json',
   } as Partial<PluginOptions>);
 
@@ -43,6 +46,20 @@ describe(`FrontMatter:`, () => {
         contents: 'CONTENTS',
       } as PageEvent;
       const { frontMatterComponent } = await generate();
+      frontMatterComponent.onPageEnd(page);
+      expect(page.contents).toMatchSnapshot();
+    });
+
+    test(`should set default index page with exports`, async () => {
+      const page = {
+        url: 'index.md',
+        model: { name: 'test-project-name' },
+        project: { name: 'test-project-name', url: 'index.md' },
+        contents: 'CONTENTS',
+      } as PageEvent;
+      const { frontMatterComponent } = await generate({}, [
+        '../typedoc-plugin-markdown/test/stubs/src/theme.ts',
+      ]);
       frontMatterComponent.onPageEnd(page);
       expect(page.contents).toMatchSnapshot();
     });

--- a/packages/typedoc-plugin-markdown/src/components/toc.ts
+++ b/packages/typedoc-plugin-markdown/src/components/toc.ts
@@ -1,12 +1,14 @@
 import { BindOption } from 'typedoc';
 import {
   DeclarationReflection,
+  ProjectReflection,
   ReflectionGroup,
 } from 'typedoc/dist/lib/models';
 import {
   Component,
   ContextAwareRendererComponent,
 } from 'typedoc/dist/lib/output/components';
+
 import { escape } from '../resources/helpers/escape';
 import MarkdownTheme from '../theme';
 
@@ -20,7 +22,7 @@ export class TableOfContents extends ContextAwareRendererComponent {
 
     MarkdownTheme.HANDLEBARS.registerHelper(
       'toc',
-      (reflection: DeclarationReflection) => {
+      (reflection: ProjectReflection | DeclarationReflection) => {
         const md: string[] = [];
         const isVisible = reflection.groups?.some((group) =>
           group.allChildrenHaveOwnDocument(),
@@ -29,18 +31,21 @@ export class TableOfContents extends ContextAwareRendererComponent {
           (!this.hideInPageTOC && reflection.groups) ||
           (isVisible && reflection.groups)
         ) {
-          md.push(`## Table of contents\n\n`);
+          if (!this.hideInPageTOC) {
+            md.push(`## Table of contents\n\n`);
+          }
+          const headingLevel = this.hideInPageTOC ? `##` : `###`;
           reflection.groups?.forEach((group) => {
             const groupTitle = group.title;
             if (group.categories) {
               group.categories.forEach((category) => {
-                md.push(`### ${category.title} ${groupTitle}\n\n`);
+                md.push(`${headingLevel} ${category.title} ${groupTitle}\n\n`);
                 pushGroup(category as any, md);
                 md.push('\n');
               });
             } else {
               if (!this.hideInPageTOC || group.allChildrenHaveOwnDocument()) {
-                md.push(`### ${groupTitle}\n\n`);
+                md.push(`${headingLevel} ${groupTitle}\n\n`);
                 pushGroup(group, md);
                 md.push('\n');
               }

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/toc.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/toc.ts
@@ -1,7 +1,7 @@
-import { ProjectReflection } from 'typedoc';
+import { DeclarationReflection, ProjectReflection } from 'typedoc';
 
 import MarkdownTheme from '../../theme';
 
-export function toc(this: ProjectReflection) {
+export function toc(this: ProjectReflection | DeclarationReflection) {
   return MarkdownTheme.HANDLEBARS.helpers.toc(this);
 }


### PR DESCRIPTION
## Motivation

Currently the sidebar for single entrypoint is 'Table of contents`. This is quite confusing as it also contains inline symbols.

This PR updates the default sidebar label to 'Exports' which also aligns with HTML theme.

This label can actually be customised with anything with the `sidebar.indexLabel` option.