### PR TITLE
Feature: Improve heading structure with disabled inline toc

### DIFF
--- a/packages/typedoc-plugin-markdown/src/components/toc.ts
+++ b/packages/typedoc-plugin-markdown/src/components/toc.ts
@@ -1,12 +1,14 @@
 import { BindOption } from 'typedoc';
 import {
   DeclarationReflection,
+  ProjectReflection,
   ReflectionGroup,
 } from 'typedoc/dist/lib/models';
 import {
   Component,
   ContextAwareRendererComponent,
 } from 'typedoc/dist/lib/output/components';
+
 import { escape } from '../resources/helpers/escape';
 import MarkdownTheme from '../theme';
 
@@ -20,7 +22,7 @@ export class TableOfContents extends ContextAwareRendererComponent {
 
     MarkdownTheme.HANDLEBARS.registerHelper(
       'toc',
-      (reflection: DeclarationReflection) => {
+      (reflection: ProjectReflection | DeclarationReflection) => {
         const md: string[] = [];
         const isVisible = reflection.groups?.some((group) =>
           group.allChildrenHaveOwnDocument(),
@@ -29,18 +31,21 @@ export class TableOfContents extends ContextAwareRendererComponent {
           (!this.hideInPageTOC && reflection.groups) ||
           (isVisible && reflection.groups)
         ) {
-          md.push(`## Table of contents\n\n`);
+          if (!this.hideInPageTOC) {
+            md.push(`## Table of contents\n\n`);
+          }
+          const headingLevel = this.hideInPageTOC ? `##` : `###`;
           reflection.groups?.forEach((group) => {
             const groupTitle = group.title;
             if (group.categories) {
               group.categories.forEach((category) => {
-                md.push(`### ${category.title} ${groupTitle}\n\n`);
+                md.push(`${headingLevel} ${category.title} ${groupTitle}\n\n`);
                 pushGroup(category as any, md);
                 md.push('\n');
               });
             } else {
               if (!this.hideInPageTOC || group.allChildrenHaveOwnDocument()) {
-                md.push(`### ${groupTitle}\n\n`);
+                md.push(`${headingLevel} ${groupTitle}\n\n`);
                 pushGroup(group, md);
                 md.push('\n');
               }

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/toc.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/toc.ts
@@ -1,7 +1,7 @@
-import { ProjectReflection } from 'typedoc';
+import { DeclarationReflection, ProjectReflection } from 'typedoc';
 
 import MarkdownTheme from '../../theme';
 
-export function toc(this: ProjectReflection) {
+export function toc(this: ProjectReflection | DeclarationReflection) {
   return MarkdownTheme.HANDLEBARS.helpers.toc(this);
 }


### PR DESCRIPTION
## Motivation

With `hideInlinePageTOC` the heading structure is confusing. 

This PR removes the 'Table of Contents' title and assigns all groups the same heading levels.