### PR TITLE
Fix string quoting bug

### DIFF
--- a/packages/typedoc-plugin-markdown/src/utils/front-matter.ts
+++ b/packages/typedoc-plugin-markdown/src/utils/front-matter.ts
@@ -44,4 +44,4 @@ ${Object.entries(vars)
 };
 
 // prettier-ignore
-const escapeString=(str: string) => str.replace(/([^\\])'/g, '$1\\\'');
+const escapeString=(str: string) => str.replace(/([^\\])"/g, '$1\\"');


### PR DESCRIPTION
Firstly, thank you for your amazing work on these plugins!

I noticed that for some of my generated files, I was getting a YAML block that looked as follows:
```
---
title: "Namespace: "QrcodeCapture""
---
```
Which led to an error when parsing the YAML. If I'm not mistaken, I think double quotes should be escaped instead of single quotes. Let me know if I'm misunderstanding something!