### PR TITLE
Remove node 12.20 requirement from typedoc-plugin-markdown

### DIFF
--- a/packages/typedoc-plugin-markdown/package.json
+++ b/packages/typedoc-plugin-markdown/package.json
@@ -20,9 +20,6 @@
   },
   "author": "Thomas Grey",
   "license": "MIT",
-  "engines": {
-    "node": ">= 12.20.0"
-  },
   "bugs": {
     "url": "https://github.com/tgreyuk/typedoc-plugin-markdown/issues"
   },


### PR DESCRIPTION
This addresses the discussion in #243 by removing the engines section of package.json, and relying on typedoc's engine enforcement via peer dependency.