### PR TITLE
fix: Fix `index` slug value

### DIFF
--- a/packages/docusaurus-plugin-typedoc/src/theme.ts
+++ b/packages/docusaurus-plugin-typedoc/src/theme.ts
@@ -92,7 +92,7 @@ export class DocusaurusTheme extends MarkdownTheme {
     if (page.url === this.entryDocument) {
       items = {
         ...items,
-        slug: '/' + path.relative(process.cwd(), this.out).replace(/\\/g, '/'),
+        slug: '/' + path.relative(process.cwd(), this.out).replace(/\\/g, '/') + '/index',
       };
     }
     if (sidebarLabel && sidebarLabel !== pageTitle) {


### PR DESCRIPTION
This fixes the `index.md`'s `slug` value.

Without this change, docususaurus complains about broken links:


```
Info: Documentation generated at ./docs/api

✔ Client
  

● Server █████████████████████████ cache (99%) shutdown IdleFileCachePlugin
 stored

Unable to build website for locale "en".
Error: Docusaurus found broken links!

Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.

Exhaustive list of all broken links found:

- On source page path = /react-native-vision-camera/docs/api:
   -> linking to classes/Camera (resolved as: /react-native-vision-camera/docs/classes/Camera)
   -> linking to classes/CameraCaptureError (resolved as: /react-native-vision-camera/docs/classes/CameraCaptureError)
   -> linking to classes/CameraRuntimeError (resolved as: /react-native-vision-camera/docs/classes/CameraRuntimeError)
   -> linking to interfaces/CameraDevice (resolved as: /react-native-vision-camera/docs/interfaces/CameraDevice)
   -> linking to interfaces/CameraDeviceFormat (resolved as: /react-native-vision-camera/docs/interfaces/CameraDeviceFormat)
   -> linking to interfaces/CameraProps (resolved as: /react-native-vision-camera/docs/interfaces/CameraProps)
   -> linking to interfaces/ErrorWithCause (resolved as: /react-native-vision-camera/docs/interfaces/ErrorWithCause)
   -> linking to interfaces/Frame (resolved as: /react-native-vision-camera/docs/interfaces/Frame)
   -> linking to interfaces/FrameProcessorPerformanceSuggestion (resolved as: /react-native-vision-camera/docs/interfaces/FrameProcessorPerformanceSuggestion)
   -> linking to interfaces/FrameRateRange (resolved as: /react-native-vision-camera/docs/interfaces/FrameRateRange)
   -> linking to interfaces/PhotoFile (resolved as: /react-native-vision-camera/docs/interfaces/PhotoFile)
   -> linking to interfaces/Point (resolved as: /react-native-vision-camera/docs/interfaces/Point)
   -> linking to interfaces/RecordVideoOptions (resolved as: /react-native-vision-camera/docs/interfaces/RecordVideoOptions)
   -> linking to interfaces/TakePhotoOptions (resolved as: /react-native-vision-camera/docs/interfaces/TakePhotoOptions)
   -> linking to interfaces/TakeSnapshotOptions (resolved as: /react-native-vision-camera/docs/interfaces/TakeSnapshotOptions)
   -> linking to interfaces/TemporaryFile (resolved as: /react-native-vision-camera/docs/interfaces/TemporaryFile)
   -> linking to interfaces/VideoFile (resolved as: /react-native-vision-camera/docs/interfaces/VideoFile)
   -> linking to index#physicalcameradevicetype (resolved as: /react-native-vision-camera/docs/index)
   -> linking to index#logicalcameradevicetype (resolved as: /react-native-vision-camera/docs/index)

- On source page path = /react-native-vision-camera/docs/api/classes/Camera:
   -> linking to ../index#usecameradevices (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#camerapermissionstatus (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#camerapermissionrequestresult (resolved as: /react-native-vision-camera/docs/api/index)

- On source page path = /react-native-vision-camera/docs/api/classes/CameraCaptureError:
   -> linking to ../index#captureerror (resolved as: /react-native-vision-camera/docs/api/index)

- On source page path = /react-native-vision-camera/docs/api/classes/CameraRuntimeError:
   -> linking to ../index#permissionerror (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#parametererror (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#deviceerror (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#formaterror (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#sessionerror (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#systemerror (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#unknownerror (resolved as: /react-native-vision-camera/docs/api/index)

- On source page path = /react-native-vision-camera/docs/api/interfaces/CameraDevice:
   -> linking to ../index#physicalcameradevicetype (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#cameraposition (resolved as: /react-native-vision-camera/docs/api/index)

- On source page path = /react-native-vision-camera/docs/api/interfaces/CameraDeviceFormat:
   -> linking to ../index#autofocussystem (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#colorspace (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#videostabilizationmode (resolved as: /react-native-vision-camera/docs/api/index)

- On source page path = /react-native-vision-camera/docs/api/interfaces/CameraProps:
   -> linking to ../index#colorspace (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#camerapreset (resolved as: /react-native-vision-camera/docs/api/index)
   -> linking to ../index#videostabilizationmode (resolved as: /react-native-vision-camera/docs/api/index)

- On source page path = /react-native-vision-camera/docs/api/interfaces/RecordVideoOptions:
   -> linking to ../index#videofiletype (resolved as: /react-native-vision-camera/docs/api/index)

    at Object.reportMessage (/Users/mrousavy/Projects/react-native-vision-camera/docs/node_modules/@docusaurus/utils/lib/index.js:308:19)
    at Object.handleBrokenLinks (/Users/mrousavy/Projects/react-native-vision-camera/docs/node_modules/@docusaurus/core/lib/server/brokenLinks.js:142:17)
    at async buildLocale (/Users/mrousavy/Projects/react-native-vision-camera/docs/node_modules/@docusaurus/core/lib/commands/build.js:160:5)
    at async tryToBuildLocale (/Users/mrousavy/Projects/react-native-vision-camera/docs/node_modules/@docusaurus/core/lib/commands/build.js:32:20)
    at async Object.mapAsyncSequencial (/Users/mrousavy/Projects/react-native-vision-camera/docs/node_modules/@docusaurus/utils/lib/index.js:263:24)
    at async build (/Users/mrousavy/Projects/react-native-vision-camera/docs/node_modules/@docusaurus/core/lib/commands/build.js:68:25)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

With this change the build works fine and no broken links are detected.

You can reproduce the error above by cloning [mrousavy/react-native-vision-camera](https://github.com/mrousavy/react-native-vision-camera), switching to [the `chore/upgrade-dependencies` branch](https://github.com/mrousavy/react-native-vision-camera/tree/chore/upgrade-dependencies), and then running the following commands:

```
yarn
yarn build
```