### PR TITLE
fix(urls): Fixes relative urls for typedoc-gitlab-wiki-theme [269]

### DIFF
--- a/packages/typedoc-gitlab-wiki-theme/src/theme.ts
+++ b/packages/typedoc-gitlab-wiki-theme/src/theme.ts
@@ -13,7 +13,10 @@ export class GitlabTheme extends MarkdownTheme {
   }
 
   getRelativeUrl(url: string) {
-    const relativeUrl = url.replace(/(.*).md/, '$1').replace(/ /g, '-');
+    const relativeUrl = super
+      .getRelativeUrl(url)
+      .replace(/(.*).md/, '$1')
+      .replace(/ /g, '-');
     return relativeUrl.startsWith('..') ? relativeUrl : './' + relativeUrl;
   }
 


### PR DESCRIPTION
This was my solution for #269 

It passes lint and tests, but I'm pretty confident this is a change that could cause regressions. I'm not sure how this plugin was working for other users, but this change was required for me to produce valid docs.