### PR TITLE
feat(vuepress-plugin-typedoc): support vuepress v2

### DIFF
--- a/packages/vuepress-plugin-typedoc/src/plugin.ts
+++ b/packages/vuepress-plugin-typedoc/src/plugin.ts
@@ -14,7 +14,7 @@ let project: ProjectReflection | undefined;
 export const typedocPlugin = (opts: PluginOptions, ctx: any) => {
   const options = getOptions(opts);
 
-  const outputDirectory = ctx.sourceDir + '/' + options.out;
+  const outputDirectory = (ctx.sourceDir || ctx.dir.source()) + '/' + options.out;
 
   removeDir(outputDirectory);
 


### PR DESCRIPTION
`sourceDir` is gone in v2.