### PR TITLE
docs(docusaurus-plugin-typedoc): add "out" option for multiple instances

### DIFF
--- a/packages/docusaurus-plugin-typedoc/README.md
+++ b/packages/docusaurus-plugin-typedoc/README.md
@@ -103,7 +103,6 @@ Options specific to the plugin should also be declared in the same object.
 | `sidebar.categoryLabel` | `API`   | The sidebar parent category label.                                                                                                                                                                           |
 | `sidebar.fullNames`     | `false` | Display full names with module path.                                                                                                                                                                         |
 | `sidebar.position`      | `auto`  | The position of the sidebar in the tree.                                                                                                                                                                     |
-| `sidebar.position`      | `auto`  | The position of the sidebar in the tree.                                                                                                                                                                     |
 
 ### An example configuration
 
@@ -229,6 +228,7 @@ module.exports = {
         id: 'api-1',
         entryPoints: ['../api-1/src/index.ts'],
         tsconfig: '../api-1/tsconfig.json',
+        out: 'api-1',
       },
     ],
     [
@@ -237,6 +237,7 @@ module.exports = {
         id: 'api-2',
         entryPoints: ['../api-2/src/index.ts'],
         tsconfig: '../api-2/tsconfig.json',
+        out: 'api-2',
       },
     ],
   ],


### PR DESCRIPTION
Hey 👋 Thanks for the great typedoc plugins!

This change will clarify the usage of multiple plugin instances, because if the `"out"` property is not specified, the second instance will override the result of the first one.