### PR TITLE
Fixed ignored plugin option cleanOutputDir

### DIFF
--- a/packages/docusaurus-plugin-typedoc/package.json
+++ b/packages/docusaurus-plugin-typedoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docusaurus-plugin-typedoc",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "A Docusaurus v2 plugin to build API documentation with TypeDoc.",
   "main": "dist/index.js",
   "files": [

--- a/packages/docusaurus-plugin-typedoc/src/options.ts
+++ b/packages/docusaurus-plugin-typedoc/src/options.ts
@@ -4,6 +4,7 @@ const DEFAULT_PLUGIN_OPTIONS: PluginOptions = {
   id: 'default',
   docsRoot: 'docs',
   out: 'api',
+  cleanOutputDir: true,
   sidebar: {
     fullNames: false,
     categoryLabel: 'API',

--- a/packages/docusaurus-plugin-typedoc/src/plugin.ts
+++ b/packages/docusaurus-plugin-typedoc/src/plugin.ts
@@ -27,7 +27,9 @@ export default function pluginDocusaurus(
 
         const outputDir = path.resolve(siteDir, options.docsRoot, options.out);
 
-        removeDir(outputDir);
+        if (opts.cleanOutputDir) {
+          removeDir(outputDir);
+        }
 
         const app = new Application();
 

--- a/packages/docusaurus-plugin-typedoc/src/types.ts
+++ b/packages/docusaurus-plugin-typedoc/src/types.ts
@@ -8,6 +8,7 @@ export interface PluginOptions {
   plugin: string[];
   readme?: string;
   disableOutputCheck?: boolean;
+  cleanOutputDir?: boolean;
   entryPoints?: string[];
   watch: boolean;
   hideInPageTOC: boolean;

--- a/packages/docusaurus-plugin-typedoc/test/specs/__snapshots__/options.spec.ts.snap
+++ b/packages/docusaurus-plugin-typedoc/test/specs/__snapshots__/options.spec.ts.snap
@@ -18,6 +18,7 @@ Array [
 
 exports[`Options: should return default options 1`] = `
 Object {
+  "cleanOutputDir": true,
   "docsRoot": "docs",
   "entryDocument": "index.md",
   "entryPoints": Array [


### PR DESCRIPTION
I'm working on adding documentation to cursorless project. We want to serve documentation both from the repository as well as hosted with docusaurus + API generated by typedoc. I'm trying to create a custom read me to serve as API index with key code pointers. 

## Ideal directory structure

Before running docusaurus-typedoc:
```
docs/
    document1.md
    api/
        code-pointers.md
```

After:
```
docs/
    document1.md
    api/ # out directory option
        code-pointers.md
        index.md # Just a copy of code-pointers.md
        ... Other typedoc documents
```

Unfortunately right now api directory gets cleaned. I have found this option https://typedoc.org/guides/options/#cleanoutputdir but looks like it's ignored by docusaurus-typedoc. This request addresses this. Only testing I have done is the unit tests which are passing. 