### PR TITLE
Added `hideMembersSymbol` option

### DIFF
--- a/packages/docusaurus-plugin-typedoc/src/options.ts
+++ b/packages/docusaurus-plugin-typedoc/src/options.ts
@@ -15,6 +15,7 @@ const DEFAULT_PLUGIN_OPTIONS: PluginOptions = {
   hideInPageTOC: true,
   hideBreadcrumbs: true,
   hidePageTitle: true,
+  hideMembersSymbol: false,
   entryDocument: 'index.md',
   plugin: ['none'],
   watch: false,

--- a/packages/docusaurus-plugin-typedoc/src/types.ts
+++ b/packages/docusaurus-plugin-typedoc/src/types.ts
@@ -14,6 +14,7 @@ export interface PluginOptions {
   hideInPageTOC: boolean;
   hideBreadcrumbs: boolean;
   hidePageTitle: boolean;
+  hideMembersSymbol: boolean;
   entryDocument: string;
   includeExtension?: boolean;
   indexSlug?: string;

--- a/packages/docusaurus-plugin-typedoc/test/specs/__snapshots__/options.spec.ts.snap
+++ b/packages/docusaurus-plugin-typedoc/test/specs/__snapshots__/options.spec.ts.snap
@@ -27,6 +27,7 @@ Object {
   "frontmatter": undefined,
   "hideBreadcrumbs": true,
   "hideInPageTOC": true,
+  "hideMembersSymbol": false,
   "hidePageTitle": true,
   "id": "default",
   "includeExtension": true,

--- a/packages/typedoc-plugin-markdown/README.md
+++ b/packages/typedoc-plugin-markdown/README.md
@@ -39,6 +39,8 @@ The following options can be used in addition to relevant [TypeDoc options](http
   Do not render breadcrumbs in template header. Defaults to `false`.
 - `--hideInPageTOC<boolean>`<br>
   Do not render in-page table of contents items.  Defaults to `false`.
+- `--hideMembersSymbol<boolean>`<br>
+  Do not add special symbols for class members.  Defaults to `false`.
 - `--publicPath<string>`<br>
   Specify the base path for all urls. If undefined urls will be relative. Defaults to `.`.
 - `--namedAnchors<boolean>`<br>

--- a/packages/typedoc-plugin-markdown/src/index.ts
+++ b/packages/typedoc-plugin-markdown/src/index.ts
@@ -66,6 +66,13 @@ export function load(app: Application) {
     name: 'indexTitle',
     type: ParameterType.String,
   });
+
+  app.options.addDeclaration({
+    help: '[Markdown Plugin] Do not add special symbols for class members.',
+    name: 'hideMembersSymbol',
+    type: ParameterType.Boolean,
+    defaultValue: false,
+  });
 }
 
 export { MarkdownTheme };

--- a/packages/typedoc-plugin-markdown/src/render-utils.ts
+++ b/packages/typedoc-plugin-markdown/src/render-utils.ts
@@ -60,7 +60,7 @@ export function registerHelpers(theme: MarkdownTheme) {
   breadcrumbsHelper(theme);
   commentHelper(theme);
   commentsHelper();
-  declarationTitleHelper();
+  declarationTitleHelper(theme);
   escapeHelper();
   hierarchyHelper();
   ifIsReference();
@@ -77,7 +77,7 @@ export function registerHelpers(theme: MarkdownTheme) {
   reflectionPathHelper();
   reflectionTitleHelper(theme);
   relativeUrlHelper(theme);
-  signatureTitleHelper();
+  signatureTitleHelper(theme);
   tocHelper(theme);
   typeHelper();
   typeAndParentHelper();

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/declaration-title.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/declaration-title.ts
@@ -12,12 +12,13 @@ import {
   stripComments,
   stripLineBreaks,
 } from '../../utils';
+import { MarkdownTheme } from '../../theme';
 
-export default function () {
+export default function (theme: MarkdownTheme) {
   Handlebars.registerHelper(
     'declarationTitle',
     function (this: ParameterReflection | DeclarationReflection) {
-      const md = [memberSymbol(this)];
+      const md = theme.hideMembersSymbol ? [] : [memberSymbol(this)];
 
       function getType(
         reflection: ParameterReflection | DeclarationReflection,

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/signature-title.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/signature-title.ts
@@ -5,14 +5,15 @@ import {
   SignatureReflection,
 } from 'typedoc';
 import { memberSymbol } from '../../utils';
+import { MarkdownTheme } from '../../theme';
 
-export default function () {
+export default function (theme: MarkdownTheme) {
   Handlebars.registerHelper(
     'signatureTitle',
     function (this: SignatureReflection, accessor?: string, standalone = true) {
       const md: string[] = [];
 
-      if (standalone) {
+      if (standalone && !theme.hideMembersSymbol) {
         md.push(`${memberSymbol(this)} `);
       }
 

--- a/packages/typedoc-plugin-markdown/src/theme.ts
+++ b/packages/typedoc-plugin-markdown/src/theme.ts
@@ -32,6 +32,7 @@ export class MarkdownTheme extends Theme {
   hideBreadcrumbs!: boolean;
   hideInPageTOC!: boolean;
   hidePageTitle!: boolean;
+  hideMembersSymbol!: boolean;
   includes!: string;
   indexTitle!: string;
   mediaDirectory!: string;
@@ -57,6 +58,7 @@ export class MarkdownTheme extends Theme {
     this.hideBreadcrumbs = this.getOption('hideBreadcrumbs') as boolean;
     this.hideInPageTOC = this.getOption('hideInPageTOC') as boolean;
     this.hidePageTitle = this.getOption('hidePageTitle') as boolean;
+    this.hideMembersSymbol = this.getOption('hideMembersSymbol') as boolean;
     this.includes = this.getOption('includes') as string;
     this.indexTitle = this.getOption('indexTitle') as string;
     this.mediaDirectory = this.getOption('media') as string;

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/members.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/members.spec.ts.snap
@@ -83,3 +83,18 @@ exports[`Members: (members) should compile module members' 1`] = `
 "
 "
 `;
+
+exports[`Members: (with hideMembersSymbol) should compile members without special symbols 1`] = `
+"### signatureMember
+
+**signatureMember**(): \`void\`
+
+#### Returns
+
+\`void\`
+
+[partial: member.sources]
+
+___
+"
+`;

--- a/packages/typedoc-plugin-markdown/test/specs/members.spec.ts
+++ b/packages/typedoc-plugin-markdown/test/specs/members.spec.ts
@@ -74,4 +74,25 @@ describe(`Members:`, () => {
       ).toMatchSnapshot();
     });
   });
+
+  describe(`(with hideMembersSymbol)`, () => {
+    beforeAll(async () => {
+      testApp = new TestApp(['members.ts']);
+      await testApp.bootstrap({
+        hideMembersSymbol: true
+      });
+      TestApp.stubPartials(['member', 'member.sources']);
+
+      memberPartial = TestApp.getPartial('member');
+    });
+
+    test(`should compile members without special symbols`, () => {
+      expect(
+        TestApp.compileTemplate(
+          memberPartial,
+          testApp.findReflection('signatureMember'),
+        ),
+      ).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
Some markdown documentation generators do not correctly handle class member special symbols. Added an option that does not add them.