### PR TITLE
feat: Added config for generating sidebar labels

### DIFF
--- a/packages/docusaurus-plugin-typedoc/src/options.ts
+++ b/packages/docusaurus-plugin-typedoc/src/options.ts
@@ -10,6 +10,7 @@ const DEFAULT_PLUGIN_OPTIONS: PluginOptions = {
     indexLabel: undefined,
     readmeLabel: 'Readme',
     position: null,
+    generateLabels: true,
   },
   hideInPageTOC: true,
   hideBreadcrumbs: true,

--- a/packages/docusaurus-plugin-typedoc/src/theme.ts
+++ b/packages/docusaurus-plugin-typedoc/src/theme.ts
@@ -122,6 +122,10 @@ export class DocusaurusTheme extends MarkdownTheme {
   }
 
   getSidebarLabel(page: PageEvent<DeclarationReflection>) {
+    if (!this.sidebar.generateLabels) {
+      return null
+    }
+
     const indexLabel =
       this.sidebar.indexLabel ||
       (this.entryPoints.length > 1 ? 'Table of contents' : 'Exports');

--- a/packages/docusaurus-plugin-typedoc/src/types.ts
+++ b/packages/docusaurus-plugin-typedoc/src/types.ts
@@ -34,6 +34,7 @@ export interface SidebarOptions {
   indexLabel?: string;
   readmeLabel?: string;
   position: number | null;
+  generateLabels?: boolean;
 }
 
 export interface SidebarCategory {


### PR DESCRIPTION
I added the ability to prevent `docusaurus-plugin-typedoc` from generating sidebar labels.

The `sidebar_label` value in markdown files takes precedence over all other configuration options [[0]](https://docusaurus.io/docs/sidebar/items#:~:text=you%20can%2C%20however%2C%20use%20the%20sidebar_label%20markdown%20front%20matter%20within%20that%20doc%2C%20which%20has%20higher%20precedence%20over%20the%20label%20key%20in%20the%20sidebar%20item.%20). Therefore, there is no way to customize sidebar labels using this plugin. 

I added a new sidebar option `generateLabels` with a default of `true`, then if it is false, then `getSidebarLabel` for a page returns `null`, so it isn't added to the frontmatter; thus allowing a user to configure that label in their `sidebar.js` (or equivalent). 

I did try to follow conventional commit rules. Please let me know if I can do better.

Thanks!