### PR TITLE
Feat/hide reflection type

### DIFF
--- a/packages/typedoc-plugin-markdown/README.md
+++ b/packages/typedoc-plugin-markdown/README.md
@@ -46,6 +46,8 @@ The following options can be used in addition to relevant [TypeDoc options](http
   Use HTML named anchors tags for implementations that do not assign header ids. Defaults to `false`.
 - `--preserveAnchorCasing<boolean>`<br>
   Preserve anchor id casing for implementations where original case is desirable. Defaults to `false`.
+- `--hideReflectionKindInTitle<boolean>`<br>
+  Do not show the reflection type in the page title.
 
 ## License
 

--- a/packages/typedoc-plugin-markdown/src/index.ts
+++ b/packages/typedoc-plugin-markdown/src/index.ts
@@ -80,6 +80,13 @@ export function load(app: Application) {
     type: ParameterType.Boolean,
     defaultValue: false,
   });
+
+  app.options.addDeclaration({
+    help: '[Markdown Plugin] Do not show the reflection type in the page title.',
+    name: 'hideReflectionKindInTitle',
+    type: ParameterType.Boolean,
+    defaultValue: false,
+  });
 }
 
 export { MarkdownTheme };

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/reflection-title.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/reflection-title.ts
@@ -11,7 +11,8 @@ export default function (theme: MarkdownTheme) {
       if (
         this.model &&
         this.model.kindString &&
-        this.url !== this.project.url
+        this.url !== this.project.url &&
+        !theme.hideReflectionKindInTitle
       ) {
         title.push(`${this.model.kindString}: `);
       }

--- a/packages/typedoc-plugin-markdown/src/theme.ts
+++ b/packages/typedoc-plugin-markdown/src/theme.ts
@@ -31,6 +31,7 @@ export class MarkdownTheme extends Theme {
   hideInPageTOC!: boolean;
   hidePageTitle!: boolean;
   hideMembersSymbol!: boolean;
+  hideReflectionKindInTitle!: boolean;
   includes!: string;
   indexTitle!: string;
   mediaDirectory!: string;
@@ -59,6 +60,9 @@ export class MarkdownTheme extends Theme {
     this.hideInPageTOC = this.getOption('hideInPageTOC') as boolean;
     this.hidePageTitle = this.getOption('hidePageTitle') as boolean;
     this.hideMembersSymbol = this.getOption('hideMembersSymbol') as boolean;
+    this.hideReflectionKindInTitle = this.getOption(
+      'hideReflectionKindInTitle',
+    ) as boolean;
     this.includes = this.getOption('includes') as string;
     this.indexTitle = this.getOption('indexTitle') as string;
     this.mediaDirectory = this.getOption('media') as string;


### PR DESCRIPTION
Apologies ahead of time for not including tests to cover this, I'm not sure exactly where/how to do that.

We're using this over on <https://tauri.app/v1/api/js/modules/app> and would like to turn off breadcrumbs (since we're using the Docusaurus ones). When we do that, the sidebar quickly becomes cluttered with `Module: foo` where `Module: ` is useless information to us.

This change allows you to disable the reflection kind if you're using a UI that would naturally highlight the kind in an organised hierarchy.