### PR TITLE
Remove broken blog link in docusaurus config

### DIFF
--- a/examples/docusaurus/docusaurus.config.js
+++ b/examples/docusaurus/docusaurus.config.js
@@ -129,10 +129,6 @@ const config = {
             title: 'More',
             items: [
               {
-                label: 'Blog',
-                to: '/blog',
-              },
-              {
                 label: 'GitHub',
                 href: 'https://github.com/facebook/docusaurus',
               },


### PR DESCRIPTION
Running `yarn build` errors out because of a broken docusaurus config in the examples. This removes the blog link since that directory doesn't exist to allow a successful build across the repo. 