### PR TITLE
Add hideReflectionKindInTitle option

### DIFF
--- a/packages/typedoc-plugin-markdown/README.md
+++ b/packages/typedoc-plugin-markdown/README.md
@@ -40,6 +40,8 @@ The following options can be used in addition to relevant [TypeDoc options](http
   Do not render in-page table of contents items. Defaults to `false`.
 - `--hideMembersSymbol<boolean>`<br>
   Do not add special symbols for class members. Defaults to `false`.
+- `--hideReflectionKindInTitle<boolean>`<br>
+  Do not show the reflection type in the page title.
 - `--publicPath<string>`<br>
   Specify the base path for all urls. If undefined urls will be relative. Defaults to `.`.
 - `--namedAnchors<boolean>`<br>

--- a/packages/typedoc-plugin-markdown/src/index.ts
+++ b/packages/typedoc-plugin-markdown/src/index.ts
@@ -75,6 +75,13 @@ export function load(app: Application) {
   });
 
   app.options.addDeclaration({
+    help: '[Markdown Plugin] Do not show the reflection type in the page title',
+    name: 'hideReflectionKindInTitle',
+    type: ParameterType.Boolean,
+    defaultValue: false,
+  });
+
+  app.options.addDeclaration({
     help: '[Markdown Plugin] Preserve anchor casing when generating links.',
     name: 'preserveAnchorCasing',
     type: ParameterType.Boolean,

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/reflection-title.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/reflection-title.ts
@@ -11,7 +11,8 @@ export default function (theme: MarkdownTheme) {
       if (
         this.model &&
         this.model.kindString &&
-        this.url !== this.project.url
+        this.url !== this.project.url &&
+        !theme.hideReflectionKindInTitle
       ) {
         title.push(`${this.model.kindString}: `);
       }

--- a/packages/typedoc-plugin-markdown/src/theme.ts
+++ b/packages/typedoc-plugin-markdown/src/theme.ts
@@ -31,6 +31,7 @@ export class MarkdownTheme extends Theme {
   hideInPageTOC!: boolean;
   hidePageTitle!: boolean;
   hideMembersSymbol!: boolean;
+  hideReflectionKindInTitle!: boolean;
   includes!: string;
   indexTitle!: string;
   mediaDirectory!: string;
@@ -59,6 +60,9 @@ export class MarkdownTheme extends Theme {
     this.hideInPageTOC = this.getOption('hideInPageTOC') as boolean;
     this.hidePageTitle = this.getOption('hidePageTitle') as boolean;
     this.hideMembersSymbol = this.getOption('hideMembersSymbol') as boolean;
+    this.hideReflectionKindInTitle = this.getOption(
+      'hideReflectionKindInTitle',
+    ) as boolean;
     this.includes = this.getOption('includes') as string;
     this.indexTitle = this.getOption('indexTitle') as string;
     this.mediaDirectory = this.getOption('media') as string;


### PR DESCRIPTION
Adds the option to hide the reflection kind in the title of a generated page to allow for "cleaner" titles (defaults to false so there is no change unless added to the config). 