### PR TITLE
Fix member reference link interpolation

### DIFF
--- a/packages/typedoc-plugin-markdown/src/partials/member.reference.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/member.reference.ts
@@ -12,8 +12,8 @@ export function referenceMember(
   }
 
   if (props.name === referenced.name) {
-    return `Re-exports <a href={urlTo(referenced)}>{referenced.name}</a>`;
+    return `Re-exports <a href=${context.urlTo(referenced)}>${referenced.name}</a>`;
   }
 
-  return `Renames and re-exports <a href={urlTo(referenced)}>{referenced.name}</a>`;
+  return `Renames and re-exports <a href=${context.urlTo(referenced)}>${referenced.name}</a>`;
 }


### PR DESCRIPTION
This fixes the issue in the `next` branch that I mentioned here: https://github.com/tgreyuk/typedoc-plugin-markdown/issues/338#issuecomment-1221420376