### PR TITLE
Quote `href` tag

### DIFF
--- a/packages/typedoc-plugin-markdown/src/partials/member.reference.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/member.reference.ts
@@ -12,8 +12,8 @@ export function referenceMember(
   }
 
   if (props.name === referenced.name) {
-    return `Re-exports <a href=${context.urlTo(referenced)}>${referenced.name}</a>`;
+    return `Re-exports <a href="${context.urlTo(referenced)}">${referenced.name}</a>`;
   }
 
-  return `Renames and re-exports <a href=${context.urlTo(referenced)}>${referenced.name}</a>`;
+  return `Renames and re-exports <a href="${context.urlTo(referenced)}">${referenced.name}</a>`;
 }


### PR DESCRIPTION
Second half of the fix from https://github.com/tgreyuk/typedoc-plugin-markdown/pull/341 (I forgot to quote the `href` tag)