### PR TITLE
Fix crash in TypeDoc 0.23.14

### DIFF
--- a/packages/typedoc-plugin-markdown/src/resources/helpers/attemptExternalResolution.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/attemptExternalResolution.ts
@@ -6,7 +6,11 @@ export default function (theme: MarkdownTheme) {
   Handlebars.registerHelper(
     'attemptExternalResolution',
     function (type: ReferenceType) {
-      return theme.owner.attemptExternalResolution(type);
+      if (theme.owner.attemptExternalResolution) {
+        return theme.owner.attemptExternalResolution(type);
+      } else {
+        return type.externalUrl;
+      }
     },
   );
 }


### PR DESCRIPTION
The attemptExternalResolution function was marked `@internal`, and therefore not considered part of the public API, so was removed when TypeDoc no longer needed it. 