### PR TITLE
[next] Fix link for member references 

### DIFF
--- a/packages/typedoc-plugin-markdown/src/partials/member.reference.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/member.reference.ts
@@ -12,8 +12,11 @@ export function referenceMember(
   }
 
   if (props.name === referenced.name) {
-    return `Re-exports <a href="${context.urlTo(referenced)}">${referenced.name}</a>`;
+    return `Re-exports [${referenced.name}](${context.urlTo(referenced)})`;
   }
 
-  return `Renames and re-exports <a href="${context.urlTo(referenced)}">${referenced.name}</a>`;
+  return `Renames and re-exports [${referenced.name}](${context.urlTo(
+    referenced,
+  )})
+  }`;
 }


### PR DESCRIPTION
Changes link from an HTML link to a markdown-style link (as `context.urlTo` keeps the `.md` extension in the returned value, it's needed otherwise it results in broken links).