### PR TITLE
[next] Add comments for return values

### DIFF
--- a/packages/typedoc-plugin-markdown/src/partials/member.signature.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/member.signature.ts
@@ -34,6 +34,13 @@ export function signatureMember(
     md.push(bold('Returns'));
     md.push(context.partials.someType(signature.type, 'all'));
 
+    if (signature.comment?.blockTags.length) {
+      const tags = signature.comment.blockTags
+        .filter((tag) => tag.tag === '@returns')
+        .map((tag) => context.partials.commentParts(tag.content));
+      md.push(tags.join('\n\n'));
+    }
+
     if (typeDeclaration?.signatures) {
       typeDeclaration.signatures.forEach((signature) => {
         md.push(context.partials.signatureMember(signature));


### PR DESCRIPTION
Reference: https://github.com/tgreyuk/typedoc-plugin-markdown/issues/338#issuecomment-1242792234

Adds back in the comment block for a signature (regression from `master`) 