### PR TITLE
[next] Wrap Titles in Code Block option

### DIFF
--- a/packages/docusaurus-plugin-typedoc/src/options.ts
+++ b/packages/docusaurus-plugin-typedoc/src/options.ts
@@ -16,7 +16,7 @@ const DEFAULT_PLUGIN_OPTIONS: PluginOptions = {
   hideInPageTOC: true,
   hideBreadcrumbs: true,
   hidePageTitle: false,
-  embedTitleInCodeBlocks: false,
+  embedHeadingsInCodeBlock: false,
   entryDocument: 'README.md',
   plugin: ['none'],
   watch: false,

--- a/packages/docusaurus-plugin-typedoc/src/options.ts
+++ b/packages/docusaurus-plugin-typedoc/src/options.ts
@@ -16,6 +16,7 @@ const DEFAULT_PLUGIN_OPTIONS: PluginOptions = {
   hideInPageTOC: true,
   hideBreadcrumbs: true,
   hidePageTitle: false,
+  embedTitleInCodeBlocks: false,
   entryDocument: 'README.md',
   plugin: ['none'],
   watch: false,

--- a/packages/docusaurus-plugin-typedoc/src/types.ts
+++ b/packages/docusaurus-plugin-typedoc/src/types.ts
@@ -14,6 +14,7 @@ export interface PluginOptions {
   hideInPageTOC: boolean;
   hideBreadcrumbs: boolean;
   hidePageTitle: boolean;
+  embedTitleInCodeBlocks: boolean;
   entryDocument: string;
   includeExtension?: boolean;
   indexSlug?: string;

--- a/packages/docusaurus-plugin-typedoc/src/types.ts
+++ b/packages/docusaurus-plugin-typedoc/src/types.ts
@@ -14,7 +14,7 @@ export interface PluginOptions {
   hideInPageTOC: boolean;
   hideBreadcrumbs: boolean;
   hidePageTitle: boolean;
-  embedTitleInCodeBlocks: boolean;
+  embedHeadingsInCodeBlock: boolean;
   entryDocument: string;
   includeExtension?: boolean;
   indexSlug?: string;

--- a/packages/typedoc-plugin-markdown/README.md
+++ b/packages/typedoc-plugin-markdown/README.md
@@ -44,6 +44,8 @@ Do not render breadcrumbs in template header. Defaults to `false`.
   Determines which symbols should be hoisted to their own document. Expected values are `None`, `All` OR Array of `['class', 'interface', 'enum', 'function', 'variable', 'type']` Defaults to `None` (all symbols included in a single module page). See [directory strategy]().
 - **`--namedAnchors`**<br>
   Use HTML named anchors tags for implementations that do not assign header ids. Defaults to `false`.
+- **`--embedHeadingsInCodeBlock`**<br>
+  Wraps the heading of a reflection in a code block. Defaults to `false`.
 
 ## License
 

--- a/packages/typedoc-plugin-markdown/src/index.ts
+++ b/packages/typedoc-plugin-markdown/src/index.ts
@@ -54,7 +54,7 @@ export function load(app: Application) {
 
   app.options.addDeclaration({
     help: '[Markdown Plugin] Wraps the heading of a reflection in a code block.',
-    name: 'embedTitleInCodeBlocks',
+    name: 'embedHeadingsInCodeBlock',
     type: ParameterType.Boolean,
     defaultValue: false,
   });

--- a/packages/typedoc-plugin-markdown/src/index.ts
+++ b/packages/typedoc-plugin-markdown/src/index.ts
@@ -53,6 +53,13 @@ export function load(app: Application) {
   });
 
   app.options.addDeclaration({
+    help: '[Markdown Plugin] Wraps the heading of a reflection in a code block.',
+    name: 'embedTitleInCodeBlocks',
+    type: ParameterType.Boolean,
+    defaultValue: false,
+  });
+
+  app.options.addDeclaration({
     help: '[Markdown Plugin] Preserve anchor casing when generating links.',
     name: 'preserveAnchorCasing',
     type: ParameterType.Boolean,

--- a/packages/typedoc-plugin-markdown/src/partials/member.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/member.ts
@@ -24,7 +24,7 @@ export function member(
       md.push(
         heading(
           headingLevel,
-          backTicks(context.partials.reflectionTitle(reflection)),
+          backTicks(context.partials.reflectionTitle(reflection, false)),
         ),
       );
     } else {

--- a/packages/typedoc-plugin-markdown/src/partials/member.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/member.ts
@@ -20,7 +20,7 @@ export function member(
   }
 
   if (!reflection.hasOwnDocument) {
-    if (context.getOption('embedTitleInCodeBlocks')) {
+    if (context.getOption('embedHeadingsInCodeBlock')) {
       md.push(
         heading(
           headingLevel,

--- a/packages/typedoc-plugin-markdown/src/partials/member.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/member.ts
@@ -3,7 +3,7 @@ import {
   ReferenceReflection,
   ReflectionKind,
 } from 'typedoc';
-import { heading } from '../els';
+import { heading, backTicks } from '../els';
 import { getTeritiaryHeadingLevel, isConstructor } from '../support/helpers';
 import { MarkdownThemeRenderContext } from '../theme-context';
 
@@ -20,9 +20,18 @@ export function member(
   }
 
   if (!reflection.hasOwnDocument) {
-    md.push(
-      heading(headingLevel, context.partials.reflectionTitle(reflection)),
-    );
+    if (context.getOption('embedTitleInCodeBlocks')) {
+      md.push(
+        heading(
+          headingLevel,
+          backTicks(context.partials.reflectionTitle(reflection)),
+        ),
+      );
+    } else {
+      md.push(
+        heading(headingLevel, context.partials.reflectionTitle(reflection)),
+      );
+    }
   }
 
   if (

--- a/packages/typedoc-plugin-markdown/src/types.ts
+++ b/packages/typedoc-plugin-markdown/src/types.ts
@@ -4,7 +4,7 @@ export interface TypedocPluginMarkdownOptions extends TypeDocOptionMap {
   hideBreadcrumbs: boolean;
   hideInPageTOC: boolean;
   hidePageTitle: boolean;
-  embedTitleInCodeBlocks: boolean;
+  embedHeadingsInCodeBlock: boolean;
   entryDocument: string;
   indexTitle: string;
   namedAnchors: boolean;

--- a/packages/typedoc-plugin-markdown/src/types.ts
+++ b/packages/typedoc-plugin-markdown/src/types.ts
@@ -4,6 +4,7 @@ export interface TypedocPluginMarkdownOptions extends TypeDocOptionMap {
   hideBreadcrumbs: boolean;
   hideInPageTOC: boolean;
   hidePageTitle: boolean;
+  embedTitleInCodeBlocks: boolean;
   entryDocument: string;
   indexTitle: string;
   namedAnchors: boolean;


### PR DESCRIPTION
Adds an option to wrap the titles of functions, interfaces, enums, etc. in a code block. This helped us be able to break up the headings (especially when you have a long module rendered all in one page) and makes it a bit easier to scan through. 

<img width="352" alt="Screenshot 2022-09-14 at 19 34 51" src="https://user-images.githubusercontent.com/15347255/190235019-cc6a23b3-d1a2-490c-aff6-37f028d80182.png">
