### PR TITLE
Add cli command to generate docs

### DIFF
--- a/packages/docusaurus-plugin-typedoc/README.md
+++ b/packages/docusaurus-plugin-typedoc/README.md
@@ -22,6 +22,8 @@ npm install typedoc typedoc-plugin-markdown docusaurus-plugin-typedoc --save-dev
 ### Config
 
 Add the plugin to `docusaurus.config.js` and specify the required options (see [options](#options)).
+You may also generate documentation with the `docusaurus generate-typedoc` command which does not require a full build.
+This can be useful for generating documentation in CI.
 
 ```js
 module.exports = {
@@ -44,6 +46,7 @@ TypeDoc will be bootstraped with the Docusaurus `start` and `build` [cli command
 ```javascript
 "start": "docusaurus start",
 "build": "docusaurus build",
+"generate-typedoc": "docusaurus generate-typedoc",
 ```
 
 Once built the docs will be available at `/docs/api` (or equivalent out directory).

--- a/packages/docusaurus-plugin-typedoc/src/plugin.ts
+++ b/packages/docusaurus-plugin-typedoc/src/plugin.ts
@@ -54,5 +54,15 @@ export default function pluginDocusaurus(
         }
       }
     },
+    extendCli(cli) {
+      cli
+        .command('generate-typedoc')
+        .description(
+          'Uses the docusaurus-plugin-typedoc to generate docs without a requiring full build',
+        )
+        .action(async () => {
+          await this.loadContent();
+        });
+    },
   };
 }


### PR DESCRIPTION
Hello! I have found a need to generate the api reference docs without running a full docusaurus build. I was able to symlink this change locally and test it on a monorepo with 3 objects in the Docusaurus config, but the cli command only generated docs for the first one.

I would love to get this working to support all options in the plugins options array, as well as add tests, but I would need some help. I couldn't figure out how to access the array of options when the command was invoked.

Thanks!