### PR TITLE
`typedoc-plugin-markdown`: beautify parameter table and signature title output of destructured params

### DIFF
--- a/packages/typedoc-plugin-markdown/src/resources/helpers/parameter-table.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/parameter-table.ts
@@ -58,11 +58,22 @@ function table(parameters: any) {
   const rows = parameters.map((parameter) => {
     const row: string[] = [];
 
-    row.push(
-      `\`${parameter.flags.isRest ? '...' : ''}${parameter.name}${
-        parameter.flags.isOptional ? '?' : ''
-      }\``,
+    const nbsp = ' '; // ? <== Unicode no-break space character
+    const rest = parameter.flags.isRest ? '...' : '';
+    const optional = parameter.flags.isOptional ? '?' : '';
+
+    const isDestructuredParam = parameter.name == '__namedParameters';
+    const isDestructuredParamProp = parameter.name.startsWith(
+      '__namedParameters.',
     );
+
+    if (isDestructuredParam) {
+      row.push(`\`${rest}«destructured»\``);
+    } else if (isDestructuredParamProp) {
+      row.push(`›${nbsp}\`${rest}${parameter.name.slice(18)}${optional}\``);
+    } else {
+      row.push(`\`${rest}${parameter.name}${optional}\``);
+    }
 
     row.push(
       parameter.type

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/signature-title.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/signature-title.ts
@@ -50,15 +50,11 @@ const getParameters = (
 ) => {
   return parameters
     .map((param) => {
-      const paramsmd: string[] = [];
-      if (param.flags.isRest) {
-        paramsmd.push('...');
-      }
-      const paramItem = `${param.name}${
-        param.flags.isOptional || param.defaultValue ? '?' : ''
-      }`;
-      paramsmd.push(backticks ? `\`${paramItem}\`` : paramItem);
-      return paramsmd.join('');
+      const isDestructuredParam = param.name == '__namedParameters';
+      const paramItem = `${param.flags.isRest ? '...' : ''}${
+        isDestructuredParam ? '«destructured»' : param.name
+      }${param.flags.isOptional || param.defaultValue ? '?' : ''}`;
+      return backticks ? `\`${paramItem}\`` : paramItem;
     })
     .join(', ');
 };

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/declarations.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/declarations.spec.ts.snap
@@ -32,7 +32,7 @@ exports[`Declarations: should compile any function type 1`] = `
 
 #### Type declaration
 
-▸ (...\`input\`): \`A\`
+▸ (\`...input\`): \`A\`
 
 ##### Parameters
 

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/signatures.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/signatures.spec.ts.snap
@@ -129,7 +129,7 @@ exports[`Signatures: should compile function with reference type' 1`] = `
 `;
 
 exports[`Signatures: should compile named parameters with comments' 1`] = `
-"▸ **functionWithNamedParamsAndComments**(\`__namedParameters?\`, \`anotherParam\`): \`void\`
+"▸ **functionWithNamedParamsAndComments**(\`«destructured»?\`, \`anotherParam\`): \`void\`
 
 FOO
 
@@ -137,9 +137,9 @@ FOO
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| \`__namedParameters\` | \`Object\` | various options |
-| \`__namedParameters.bar?\` | \`number\` | - |
-| \`__namedParameters.foo?\` | \`number\` | - |
+| \`«destructured»\` | \`Object\` | various options |
+|  › \`bar?\` | \`number\` | - |
+|  › \`foo?\` | \`number\` | - |
 | \`anotherParam\` | \`string\` | Another param comment |
 
 ##### Returns
@@ -149,13 +149,13 @@ FOO
 `;
 
 exports[`Signatures: should compile named parameters' 1`] = `
-"▸ **functionWithNamedParams**(\`__namedParameters\`): \`string\`
+"▸ **functionWithNamedParams**(\`«destructured»\`): \`string\`
 
 ##### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| \`__namedParameters\` | \`Object\` |
+| \`«destructured»\` | \`Object\` |
 
 ##### Returns
 
@@ -260,7 +260,7 @@ This is a function with multiple arguments and a return value.
 `;
 
 exports[`Signatures: should compile signature with rest params' 1`] = `
-"▸ **functionWithRest**(...\`rest\`): \`string\`
+"▸ **functionWithRest**(\`...rest\`): \`string\`
 
 This is a function with rest parameter.
 
@@ -277,7 +277,7 @@ This is a function with rest parameter.
 `;
 
 exports[`Signatures: should compile signature with union types' 1`] = `
-"▸ **functionWithUnionTypes**(\`arg\`, ...\`args\`): \`any\`
+"▸ **functionWithUnionTypes**(\`arg\`, \`...args\`): \`any\`
 
 ##### Parameters
 


### PR DESCRIPTION
First off, thank you for typedoc and typedoc-plugin-markdown, they've done wonders for my documentation game :)

So I've been using [a forked version](https://github.com/xunnamius/typedoc-plugin-markdown) of the typedoc-plugin-markdown package that updates how [destructured parameters](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) are represented in Markdown.

For example:

```typescript
export function deleteme(...[x, y]: [number, string]) {
  console.log(x, y);
}

export function deleteme2(
  { a = true, b = true }: { a?: boolean; b?: boolean } = {},
  state: boolean,
  fate: number
) {
  console.log(a, b, state, fate);
}

export function deleteme3(
  { a = true, b = true }: { a?: boolean; b?: boolean } = {},
  { c = true, d = true }: { c?: boolean; d?: boolean } = {},
  state: boolean,
  fate: number,
  { e = true, f = true }: { e?: boolean; f?: boolean } = {}
) {
  console.log(a, b, c, d, e, f, state, fate);
}
```

<details><summary>Yields (using my fork):</summary>
<p>

### deleteme

▸ **deleteme**(`...«destructured»`): void

#### Parameters

| Name | Type |
| :------ | :------ |
| `...«destructured»` | [number, string] |

#### Returns

void

#### Defined in

[index.ts:8](#)

___

### deleteme2

▸ **deleteme2**(`«destructured»?`, `state`, `fate`): void

#### Parameters

| Name | Type |
| :------ | :------ |
| `«destructured»` | Object |
|  › `a?` | boolean |
|  › `b?` | boolean |
| `state` | boolean |
| `fate` | number |

#### Returns

void

#### Defined in

[index.ts:12](#)

___

### deleteme3

▸ **deleteme3**(`«destructured»?`, `«destructured»?`, `state`, `fate`, `«destructured»?`): void

#### Parameters

| Name | Type |
| :------ | :------ |
| `«destructured»` | Object |
|  › `a?` | boolean |
|  › `b?` | boolean |
| `«destructured»` | Object |
|  › `c?` | boolean |
|  › `d?` | boolean |
| `state` | boolean |
| `fate` | number |
| `«destructured»` | Object |
|  › `e?` | boolean |
|  › `f?` | boolean |

#### Returns

void

#### Defined in

[index.ts:20](#)

</p>
</details>

<details><summary>Yields (not using my fork):</summary>
<p>

### deleteme

▸ **deleteme**(...`__namedParameters`): `void`

#### Parameters

| Name | Type |
| :------ | :------ |
| `...__namedParameters` | [`number`, `string`] |

#### Returns

`void`

#### Defined in

[index.ts:8](#)

___

### deleteme2

▸ **deleteme2**(`__namedParameters?`, `state`, `fate`): `void`

#### Parameters

| Name | Type |
| :------ | :------ |
| `__namedParameters` | `Object` |
| `__namedParameters.a?` | `boolean` |
| `__namedParameters.b?` | `boolean` |
| `state` | `boolean` |
| `fate` | `number` |

#### Returns

`void`

#### Defined in

[index.ts:12](#)

___

### deleteme3

▸ **deleteme3**(`__namedParameters?`, `__namedParameters?`, `state`, `fate`, `__namedParameters?`): `void`

#### Parameters

| Name | Type |
| :------ | :------ |
| `__namedParameters` | `Object` |
| `__namedParameters.a?` | `boolean` |
| `__namedParameters.b?` | `boolean` |
| `__namedParameters` | `Object` |
| `__namedParameters.c?` | `boolean` |
| `__namedParameters.d?` | `boolean` |
| `state` | `boolean` |
| `fate` | `number` |
| `__namedParameters` | `Object` |
| `__namedParameters.e?` | `boolean` |
| `__namedParameters.f?` | `boolean` |

#### Returns

`void`

#### Defined in

[index.ts:20](#)

</p>
</details>

Along with updated tests, I'm currently using my forked version across several projects if you want to test it out real quick:

```shell
npm install --save-dev https://xunn.at/typedoc-plugin-markdown
npx typedoc --plugin typedoc-plugin-markdown --out demo --readme none './src/*'
```