### PR TITLE
[next] Horizontal Divider

### DIFF
--- a/packages/docusaurus-plugin-typedoc/src/options.ts
+++ b/packages/docusaurus-plugin-typedoc/src/options.ts
@@ -17,6 +17,7 @@ const DEFAULT_PLUGIN_OPTIONS: PluginOptions = {
   hideBreadcrumbs: true,
   hidePageTitle: false,
   embedHeadingsInCodeBlock: false,
+  hideHorizontalDivider: false,
   entryDocument: 'README.md',
   plugin: ['none'],
   watch: false,

--- a/packages/docusaurus-plugin-typedoc/src/types.ts
+++ b/packages/docusaurus-plugin-typedoc/src/types.ts
@@ -15,6 +15,7 @@ export interface PluginOptions {
   hideBreadcrumbs: boolean;
   hidePageTitle: boolean;
   embedHeadingsInCodeBlock: boolean;
+  hideHorizontalDivider: boolean;
   entryDocument: string;
   includeExtension?: boolean;
   indexSlug?: string;

--- a/packages/typedoc-plugin-markdown/README.md
+++ b/packages/typedoc-plugin-markdown/README.md
@@ -40,6 +40,8 @@ Do not render breadcrumbs in template header. Defaults to `false`.
   Do not render breadcrumbs in template header. Defaults to `false`.
 - **`--hideInPageTOC`**<br>
   Do not add special symbols for class members. Defaults to `false`.
+- **`--hideHorizontalDivider`**<br>
+  Do not render horizontal divider between content. Defaults to `false`.
 - **`--hasOwnDocument`**<br>
   Determines which symbols should be hoisted to their own document. Expected values are `None`, `All` OR Array of `['class', 'interface', 'enum', 'function', 'variable', 'type']` Defaults to `None` (all symbols included in a single module page). See [directory strategy]().
 - **`--namedAnchors`**<br>

--- a/packages/typedoc-plugin-markdown/src/els.ts
+++ b/packages/typedoc-plugin-markdown/src/els.ts
@@ -1,3 +1,5 @@
+import { MarkdownThemeRenderContext } from './theme-context';
+
 export const heading = (level: number, text: string) =>
   `${[...Array(level)].map(() => '#').join('')} ${text}`;
 
@@ -11,7 +13,15 @@ export const backTicks = (text: string) => `\`${text}\``;
 export const unorderedList = <T>(items: T[]) =>
   items.map((item) => `- ${item}`).join('\n');
 
-export const horizontalRule = () => '\n\n---';
+export function horizontalRule(context: MarkdownThemeRenderContext) {
+  const hideHorizontalDivider = context.getOption('hideHorizontalDivider');
+
+  if (hideHorizontalDivider) {
+    return '\n\n';
+  } else {
+    return '\n\n---';
+  }
+}
 
 export const table = (headers: string[], rows: string[][]) =>
   `\n| ${headers.join(' | ')} |\n| ${headers

--- a/packages/typedoc-plugin-markdown/src/index.ts
+++ b/packages/typedoc-plugin-markdown/src/index.ts
@@ -60,6 +60,13 @@ export function load(app: Application) {
   });
 
   app.options.addDeclaration({
+    help: '[Markdown Plugin] Do not render horizontal divider between content.',
+    name: 'hideHorizontalDivider',
+    type: ParameterType.Boolean,
+    defaultValue: false,
+  });
+
+  app.options.addDeclaration({
     help: '[Markdown Plugin] Preserve anchor casing when generating links.',
     name: 'preserveAnchorCasing',
     type: ParameterType.Boolean,

--- a/packages/typedoc-plugin-markdown/src/partials/members.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/members.ts
@@ -36,12 +36,12 @@ export function members(
             .forEach((groupChild, index) => {
               md.push(context.partials.member(groupChild));
               if (index !== group.children.length - 1) {
-                md.push(horizontalRule());
+                md.push(horizontalRule(context));
               }
             });
           if (container.groups && container.groups.length) {
             if (groupIndex !== container.groups.length - 1) {
-              md.push(horizontalRule());
+              md.push(horizontalRule(context));
             }
           }
         }

--- a/packages/typedoc-plugin-markdown/src/partials/reflection.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/reflection.ts
@@ -52,7 +52,7 @@ export function reflection(
 
   md.push(context.partials.toc(reflection));
 
-  md.push(horizontalRule());
+  md.push(horizontalRule(context));
 
   md.push(context.partials.members(reflection));
 

--- a/packages/typedoc-plugin-markdown/src/types.ts
+++ b/packages/typedoc-plugin-markdown/src/types.ts
@@ -5,6 +5,7 @@ export interface TypedocPluginMarkdownOptions extends TypeDocOptionMap {
   hideInPageTOC: boolean;
   hidePageTitle: boolean;
   embedHeadingsInCodeBlock: boolean;
+  hideHorizontalDivider: boolean;
   entryDocument: string;
   indexTitle: string;
   namedAnchors: boolean;


### PR DESCRIPTION
When we have a module on one single page, the horizontal dividers could become repetitive (especially for shorter definitions). This gives a global option to disable the horizontal divider. 