### PR TITLE
[next] Fix escaped chars in backticks

### DIFF
--- a/packages/typedoc-plugin-markdown/src/partials/type.some.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/type.some.ts
@@ -81,5 +81,5 @@ export function someType(
     return '' + context.partials.unknownType(someType);
   }
 
-  return backTicks(escapeChars(someType?.toString()));
+  return backTicks(someType?.toString());
 }

--- a/packages/typedoc-plugin-markdown/src/partials/type.unknown.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/type.unknown.ts
@@ -7,5 +7,5 @@ export function unknownType(
   context: MarkdownThemeRenderContext,
   model: UnknownType,
 ) {
-  return backTicks(escapeChars(model.name));
+  return backTicks(model.name);
 }


### PR DESCRIPTION
Previously some back-ticked content was escaping characters. When this is done in code blocks it was causing unwanted escaping (see the `x86\_64` entry when it should just be `x86_64`: 

<img width="890" alt="Screenshot 2022-12-03 at 11 52 48" src="https://user-images.githubusercontent.com/15347255/205439619-9e378d7e-a3ef-49d4-88c6-5f405df9b8a2.png">

Now this removes any redundant escaping:

<img width="890" alt="Screenshot 2022-12-03 at 11 53 18" src="https://user-images.githubusercontent.com/15347255/205439642-f1354949-27ad-4fd9-8d4c-4ac5300093aa.png">

In the future if there are things that should be escaped WITHIN backtick blocks, I'd assume that should be handled inside the `backTicks` function and not by wrapping that in `escapeChars`