### PR TITLE
[next] Change Signature Styling

### DIFF
--- a/packages/typedoc-plugin-markdown/src/partials/member.declaration.title.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/member.declaration.title.ts
@@ -13,7 +13,7 @@ export function declarationMemberTitle(
   context: MarkdownThemeRenderContext,
   reflection: ParameterReflection | DeclarationReflection,
 ) {
-  const md: string[] = [''];
+  const md: string[] = ['> '];
 
   if (
     reflection.flags &&

--- a/packages/typedoc-plugin-markdown/src/partials/member.signature.title.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/member.signature.title.ts
@@ -6,7 +6,7 @@ export function signatureTitle(
   signature: SignatureReflection,
   accessor?: string,
 ) {
-  const md: string[] = ['» '];
+  const md: string[] = ['> '];
 
   if (signature.parent && signature.parent.flags?.length > 0) {
     md.push(

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/declarations.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/declarations.spec.ts.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Declarations: should compile a const with default value 1`] = `
-"\`Const\` **stringConstWithDefaultValue**: \`"hello"\`
+"> \`Const\` **stringConstWithDefaultValue**: \`"hello"\`
 
 [partial: sources]"
 `;
 
 exports[`Declarations: should compile a let with default value 1`] = `
-" **stringLetWithDefaultValue**: \`string\` = \`'hello'\`
+">  **stringLetWithDefaultValue**: \`string\` = \`'hello'\`
 
 [partial: sources]"
 `;
 
 exports[`Declarations: should compile an undefined declaration 1`] = `
-" **undefinedNumberDeclaration**: \`number\`
+">  **undefinedNumberDeclaration**: \`number\`
 
 [partial: sources]"
 `;
 
 exports[`Declarations: should compile any function type 1`] = `
-" **AnyFunctionType**<\`A\`\\>: (...\`input\`: \`any\`[]) => \`A\`
+">  **AnyFunctionType**<\`A\`\\>: (...\`input\`: \`any\`[]) => \`A\`
 
 **Type parameters**
 
@@ -28,7 +28,7 @@ exports[`Declarations: should compile any function type 1`] = `
 
 **Type declaration**
 
-» (...\`input\`: \`any\`[]): \`A\`
+> (...\`input\`: \`any\`[]): \`A\`
 
 **Parameters**
 
@@ -46,7 +46,7 @@ exports[`Declarations: should compile any function type 1`] = `
 `;
 
 exports[`Declarations: should compile declaration with accessors 1`] = `
-" **getterAndSetter**: \`Object\`
+">  **getterAndSetter**: \`Object\`
 
 **Type declaration**
 
@@ -61,31 +61,31 @@ exports[`Declarations: should compile declaration with accessors 1`] = `
 `;
 
 exports[`Declarations: should compile declaration with double underscores in name and value 1`] = `
-"\`Const\` **\\_\\_DOUBLE\\_UNDERSCORES\\_DECLARATION\\_\\_**: typeof [\`__DOUBLE_UNDERSCORES_DECLARATION__\`](Modules.md#__double_underscores_declaration__)
+"> \`Const\` **\\_\\_DOUBLE\\_UNDERSCORES\\_DECLARATION\\_\\_**: typeof [\`__DOUBLE_UNDERSCORES_DECLARATION__\`](Modules.md#__double_underscores_declaration__)
 
 [partial: sources]"
 `;
 
 exports[`Declarations: should compile enum declaration 1`] = `
-" **Down** = \`1\`
+">  **Down** = \`1\`
 
 [partial: sources]"
 `;
 
 exports[`Declarations: should compile enum declaration with defaults 1`] = `
-" **East** = \`"East"\`
+">  **East** = \`"East"\`
 
 [partial: sources]"
 `;
 
 exports[`Declarations: should compile function declaration 1`] = `
-" **functionDeclaration**: 
+">  **functionDeclaration**: 
 
 [partial: sources]"
 `;
 
 exports[`Declarations: should compile indexable declaration 1`] = `
-" **indexableDeclaration**: \`Object\`
+">  **indexableDeclaration**: \`Object\`
 
 context.indexSignaturePartial(typeDeclaration.indexSignature)
 
@@ -101,7 +101,7 @@ context.indexSignaturePartial(typeDeclaration.indexSignature)
 `;
 
 exports[`Declarations: should compile object literal cast as a const 1`] = `
-"\`Const\` **objectLiteralAsConstDeclaration**: \`Object\`
+"> \`Const\` **objectLiteralAsConstDeclaration**: \`Object\`
 
 Comments
 
@@ -131,7 +131,7 @@ Comment for Prop2.
 `;
 
 exports[`Declarations: should compile object literal declaration 1`] = `
-"\`Const\` **objectLiteralDeclaration**: \`Object\`
+"> \`Const\` **objectLiteralDeclaration**: \`Object\`
 
 **\`Param\`**
 
@@ -164,7 +164,7 @@ description for valueY
 `;
 
 exports[`Declarations: should compile type literal declaration 1`] = `
-" **typeLiteralDeclaration**: \`Object\`
+">  **typeLiteralDeclaration**: \`Object\`
 
 **Type declaration**
 

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/generics.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/generics.spec.ts.snap
@@ -19,7 +19,7 @@ exports[`Generics: should compile class with type params 1`] = `
 `;
 
 exports[`Generics: should compile function with a simple type param' 1`] = `
-"» **functionWithTypeParam**<\`A\`\\>(): \`boolean\`
+"> **functionWithTypeParam**<\`A\`\\>(): \`boolean\`
 
 **Type parameters**
 
@@ -32,7 +32,7 @@ exports[`Generics: should compile function with a simple type param' 1`] = `
 `;
 
 exports[`Generics: should compile function with complex type params' 1`] = `
-"» **functionWithTypeParams**<\`A\`, \`B\`, \`C\`\\>(): \`boolean\`
+"> **functionWithTypeParams**<\`A\`, \`B\`, \`C\`\\>(): \`boolean\`
 
 [partial: comment]
 
@@ -49,13 +49,13 @@ exports[`Generics: should compile function with complex type params' 1`] = `
 `;
 
 exports[`Generics: should compile generics with defaults' 1`] = `
-" **genericsWithDefaults**: 
+">  **genericsWithDefaults**: 
 
 [partial: sources]"
 `;
 
 exports[`Generics: should compile type with nested generics' 1`] = `
-" **nestedGenerics**: [\`Generic1\`](Modules.md#generic1)<[\`Generic2\`](Modules.md#generic2)<[\`Generic3\`](Modules.md#generic3)<\`string\`\\>\\>\\>
+">  **nestedGenerics**: [\`Generic1\`](Modules.md#generic1)<[\`Generic2\`](Modules.md#generic2)<[\`Generic3\`](Modules.md#generic3)<\`string\`\\>\\>\\>
 
 [partial: sources]"
 `;

--- a/packages/typedoc-plugin-markdown/test/specs/__snapshots__/signatures.spec.ts.snap
+++ b/packages/typedoc-plugin-markdown/test/specs/__snapshots__/signatures.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Signatures: should compile a promise that returns a symbol' 1`] = `
-"» **promiseReturningASymbol**(): [\`Promise\`]( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise )<[\`User\`](Modules.md#user)\\>
+"> **promiseReturningASymbol**(): [\`Promise\`]( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise )<[\`User\`](Modules.md#user)\\>
 
 **Returns**
 
@@ -9,7 +9,7 @@ exports[`Signatures: should compile a promise that returns a symbol' 1`] = `
 `;
 
 exports[`Signatures: should compile a promise that returns an object' 1`] = `
-"» **promiseReturningAnObject**(): [\`Promise\`]( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise )<{ \`data\`: \`string\` ; \`id\`: \`string\`  }\\>
+"> **promiseReturningAnObject**(): [\`Promise\`]( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise )<{ \`data\`: \`string\` ; \`id\`: \`string\`  }\\>
 
 **Returns**
 
@@ -17,7 +17,7 @@ exports[`Signatures: should compile a promise that returns an object' 1`] = `
 `;
 
 exports[`Signatures: should compile callable signature' 1`] = `
-"» **CallableSignature**(): \`string\`
+"> **CallableSignature**(): \`string\`
 
 **Returns**
 
@@ -25,7 +25,7 @@ exports[`Signatures: should compile callable signature' 1`] = `
 `;
 
 exports[`Signatures: should compile class with constructor' 1`] = `
-"» **new ClassWithConstructor**(\`x\`: \`string\`, \`y\`: \`string\`): [\`ClassWithConstructor\`](Modules.md#classwithconstructor)
+"> **new ClassWithConstructor**(\`x\`: \`string\`, \`y\`: \`string\`): [\`ClassWithConstructor\`](Modules.md#classwithconstructor)
 
 **Parameters**
 
@@ -42,7 +42,7 @@ exports[`Signatures: should compile class with constructor' 1`] = `
 `;
 
 exports[`Signatures: should compile function that returns a function' 1`] = `
-"» **functionReturningAFunction**(): <T\\>(\`x\`: \`string\`) => \`boolean\`
+"> **functionReturningAFunction**(): <T\\>(\`x\`: \`string\`) => \`boolean\`
 
 Comments for function
 
@@ -54,7 +54,7 @@ Comments for function
 
 Return comments
 
-» <\`T\`\\>(\`x\`: \`string\`): \`boolean\`
+> <\`T\`\\>(\`x\`: \`string\`): \`boolean\`
 
 **Type parameters**
 
@@ -75,7 +75,7 @@ Return comments
 `;
 
 exports[`Signatures: should compile function that returns an object' 1`] = `
-"» **functionReturningAnObject**(): \`Object\`
+"> **functionReturningAnObject**(): \`Object\`
 
 Comments for function
 
@@ -96,7 +96,7 @@ Return comments
 `;
 
 exports[`Signatures: should compile function with nested typen params' 1`] = `
-"» **functionWithNestedParams**(\`params\`: \`Object\`, \`context\`: \`any\`): \`boolean\`
+"> **functionWithNestedParams**(\`params\`: \`Object\`, \`context\`: \`any\`): \`boolean\`
 
 Some nested params.
 
@@ -122,7 +122,7 @@ Some nested params.
 `;
 
 exports[`Signatures: should compile function with reference type' 1`] = `
-"» **functionWithReferenceType**(\`descriptor\`: \`TypedPropertyDescriptor\`<\`any\`\\>): \`boolean\`
+"> **functionWithReferenceType**(\`descriptor\`: \`TypedPropertyDescriptor\`<\`any\`\\>): \`boolean\`
 
 **Parameters**
 
@@ -138,7 +138,7 @@ exports[`Signatures: should compile function with reference type' 1`] = `
 `;
 
 exports[`Signatures: should compile named parameters with comments' 1`] = `
-"» **functionWithNamedParamsAndComments**(\`«destructured»?\`: \`Object\`, \`anotherParam\`: \`string\`): \`void\`
+"> **functionWithNamedParamsAndComments**(\`«destructured»?\`: \`Object\`, \`anotherParam\`: \`string\`): \`void\`
 
 FOO
 
@@ -159,7 +159,7 @@ FOO
 `;
 
 exports[`Signatures: should compile named parameters' 1`] = `
-"» **functionWithNamedParams**(\`«destructured»\`: \`Object\`): \`string\`
+"> **functionWithNamedParams**(\`«destructured»\`: \`Object\`): \`string\`
 
 **Parameters**
 
@@ -175,7 +175,7 @@ exports[`Signatures: should compile named parameters' 1`] = `
 `;
 
 exports[`Signatures: should compile pipes in params and comments' 1`] = `
-"» **functionWithPipesInParamsAndComments**(\`n\`: \`number\`): \`number\` \\| \`null\`
+"> **functionWithPipesInParamsAndComments**(\`n\`: \`number\`): \`number\` \\| \`null\`
 
 
 
@@ -193,7 +193,7 @@ exports[`Signatures: should compile pipes in params and comments' 1`] = `
 `;
 
 exports[`Signatures: should compile signature with @return comments' 1`] = `
-"» **commentsInReturn**(): \`boolean\`
+"> **commentsInReturn**(): \`boolean\`
 
 Comments with a return definition
 
@@ -207,7 +207,7 @@ Return comments"
 `;
 
 exports[`Signatures: should compile signature with a flag' 1`] = `
-"» \`Private\` **privateFunction**(): \`string\`
+"> \`Private\` **privateFunction**(): \`string\`
 
 
 
@@ -217,7 +217,7 @@ exports[`Signatures: should compile signature with a flag' 1`] = `
 `;
 
 exports[`Signatures: should compile signature with default values' 1`] = `
-"» **functionWithDefaults**(\`valueA?\`: \`string\`, \`valueB?\`: \`number\`, \`valueC?\`: \`number\`, \`valueD?\`: \`boolean\`, \`valueE?\`: \`boolean\`, \`valueF?\`: \`string\`): \`string\`
+"> **functionWithDefaults**(\`valueA?\`: \`string\`, \`valueB?\`: \`number\`, \`valueC?\`: \`number\`, \`valueD?\`: \`boolean\`, \`valueE?\`: \`boolean\`, \`valueF?\`: \`string\`): \`string\`
 
 This is a function with a parameter that has a default value.
 
@@ -240,7 +240,7 @@ This is a function with a parameter that has a default value.
 `;
 
 exports[`Signatures: should compile signature with optional params' 1`] = `
-"» **functionWithOptionalParam**(\`requiredParam\`: \`string\`, \`optionalParam?\`: \`string\`): \`void\`
+"> **functionWithOptionalParam**(\`requiredParam\`: \`string\`, \`optionalParam?\`: \`string\`): \`void\`
 
 This is a function with a parameter that is optional.
 
@@ -259,7 +259,7 @@ This is a function with a parameter that is optional.
 `;
 
 exports[`Signatures: should compile signature with params' 1`] = `
-"» **functionWithParameters**(\`paramZ\`: \`string\`, \`paramG\`: \`any\`, \`paramA\`: \`any\`): \`number\`
+"> **functionWithParameters**(\`paramZ\`: \`string\`, \`paramG\`: \`any\`, \`paramA\`: \`any\`): \`number\`
 
 This is a function with multiple arguments and a return value.
 
@@ -279,7 +279,7 @@ This is a function with multiple arguments and a return value.
 `;
 
 exports[`Signatures: should compile signature with rest params' 1`] = `
-"» **functionWithRest**(...\`rest\`: \`string\`[]): \`string\`
+"> **functionWithRest**(...\`rest\`: \`string\`[]): \`string\`
 
 This is a function with rest parameter.
 
@@ -297,7 +297,7 @@ This is a function with rest parameter.
 `;
 
 exports[`Signatures: should compile signature with union types' 1`] = `
-"» **functionWithUnionTypes**(\`arg\`: \`number\` \\| \`boolean\`[], ...\`args\`: (\`string\` \\| \`number\`)[]): \`any\`
+"> **functionWithUnionTypes**(\`arg\`: \`number\` \\| \`boolean\`[], ...\`args\`: (\`string\` \\| \`number\`)[]): \`any\`
 
 **Parameters**
 


### PR DESCRIPTION
This changes the design of member signature titles as well as member declaration titles from this:
 
<img width="980" alt="Screenshot 2022-12-14 at 20 11 16" src="https://user-images.githubusercontent.com/15347255/207704976-1aa224bf-240b-48fb-9dc8-1e6f62637e79.png">

to this:

<img width="276" alt="Screenshot 2022-12-14 at 20 11 26" src="https://user-images.githubusercontent.com/15347255/207704996-23c4fa8a-4c99-4c1c-b8d2-0e385af05db7.png">
