### PR TITLE
[next] Fix typo in member reference file

### DIFF
--- a/packages/typedoc-plugin-markdown/src/partials/member.reference.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/member.reference.ts
@@ -17,6 +17,5 @@ export function referenceMember(
 
   return `Renames and re-exports [${referenced.name}](${context.urlTo(
     referenced,
-  )})
-  }`;
+  )})`;
 }


### PR DESCRIPTION
Fix a typo I introduced in bad437101b7bc00280d780e13273859b05eab8e3