### PR TITLE
[next] Remove horizontalRule usage for reflections

### DIFF
--- a/packages/typedoc-plugin-markdown/src/partials/reflection.ts
+++ b/packages/typedoc-plugin-markdown/src/partials/reflection.ts
@@ -1,5 +1,5 @@
 import { DeclarationReflection } from 'typedoc';
-import { bold, heading, horizontalRule, unorderedList } from '../support/els';
+import { bold, heading, unorderedList } from '../support/els';
 import { getSecondaryHeadingLevel } from '../support/helpers';
 import { MarkdownThemeRenderContext } from '../theme-context';
 
@@ -51,8 +51,6 @@ export function reflection(
   }
 
   md.push(context.partials.toc(reflection));
-
-  md.push(horizontalRule());
 
   md.push(context.partials.members(reflection));
 


### PR DESCRIPTION
Removes usage of `horizontalRule` throughout code but retains the helper function for future use per https://github.com/tgreyuk/typedoc-plugin-markdown/discussions/372#discussioncomment-4403613