### PR TITLE
Use escapeChars in signature-title

### DIFF
--- a/packages/typedoc-plugin-markdown/src/resources/helpers/signature-title.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/signature-title.ts
@@ -22,7 +22,7 @@ export default function (theme: MarkdownTheme) {
       }
 
       if (accessor) {
-        md.push(`\`${accessor}\` **${escapeChars(this.name)}}**`);
+        md.push(`\`${accessor}\` **${escapeChars(this.name)}**`);
       } else if (this.name !== '__call' && this.name !== '__type') {
         md.push(`**${escapeChars(this.name)}**`);
       }

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/signature-title.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/signature-title.ts
@@ -4,7 +4,7 @@ import {
   ReflectionKind,
   SignatureReflection,
 } from 'typedoc';
-import { memberSymbol } from '../../utils';
+import { escapeChars, memberSymbol } from '../../utils';
 import { MarkdownTheme } from '../../theme';
 
 export default function (theme: MarkdownTheme) {
@@ -22,9 +22,9 @@ export default function (theme: MarkdownTheme) {
       }
 
       if (accessor) {
-        md.push(`\`${accessor}\` **${this.name}**`);
+        md.push(`\`${accessor}\` **${escapeChars(this.name)}}**`);
       } else if (this.name !== '__call' && this.name !== '__type') {
-        md.push(`**${this.name}**`);
+        md.push(`**${escapeChars(this.name)}**`);
       }
 
       if (this.typeParameters) {


### PR DESCRIPTION
Hi! 👋🏼 

We're using your plugin and one of our methods looks like `__unsafe__blahBlah()` which was rendering as `unsafeblahBlah()`in this signature title because the underscores were not being escaped. This PR fixes that. Let me know if you need tests or anything.