### PR TITLE
Enable the package.json loader, so options may be read from typedocOptions

### DIFF
--- a/packages/docusaurus-plugin-typedoc/src/render.ts
+++ b/packages/docusaurus-plugin-typedoc/src/render.ts
@@ -3,6 +3,7 @@ import {
   Application,
   BooleanDeclarationOption,
   MixedDeclarationOption,
+  PackageJsonReader,
   ParameterType,
   ProjectReflection,
   RendererEvent,
@@ -46,6 +47,7 @@ export async function render(
 }
 
 const addTypedocReaders = (app: Application) => {
+  app.options.addReader(new PackageJsonReader())
   app.options.addReader(new TypeDocReader());
   app.options.addReader(new TSConfigReader());
 };


### PR DESCRIPTION
This was driving me crazy. Turns out `docusaurus-plugin-typedoc` doesn't read `typedocOptions` from `package.json`, even though the `typedoc` command line tool does.

PS. Maybe add these lines to `vuepress-plugin-typedoc` as well?
