### PR TITLE
docs: fix typedoc options link in README

### DIFF
--- a/packages/docusaurus-plugin-typedoc/README.md
+++ b/packages/docusaurus-plugin-typedoc/README.md
@@ -67,7 +67,7 @@ Once built the docs will be available at `/docs/api` (or equivalent out director
 
 ### TypeDoc options
 
-To configure TypeDoc, pass any relevant [TypeDoc options](https://typedoc.org/guides/options/) to the config.
+To configure TypeDoc, pass any relevant [TypeDoc options](https://typedoc.org/options/) to the config.
 
 At a minimum the `entryPoints` and `tsconfig` options will need to be set.
 


### PR DESCRIPTION
The existing https://typedoc.org/guides/options/ link in the README is returning a 404. This updates the link to https://typedoc.org/options/, which is working for me.