### PR TITLE
Remove extra comment

### DIFF
--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/member.signature.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/member.signature.ts
@@ -80,10 +80,6 @@ export function signatureMember(
 
   md.push(context.inheritance(signature, headingLevel));
 
-  if (signature.comment) {
-    md.push(context.comment(signature.comment, headingLevel, false, true));
-  }
-
   if (showSources && signature.sources) {
     md.push(context.sources(signature, headingLevel));
   }


### PR DESCRIPTION
Signatures were generating summaries twice, you can see this in a function signature.

Tests are disabled (I think due to typedoc 0.25 breaking changes that just came out?) so no tests updated for this one that would have caught it. 