### PR TITLE
fix: plugin not load

### DIFF
--- a/packages/docusaurus-plugin-typedoc/src/plugin.ts
+++ b/packages/docusaurus-plugin-typedoc/src/plugin.ts
@@ -63,7 +63,9 @@ async function generateTypedoc(
     removeDir(outputDir);
   }
 
-  const app = await Application.bootstrapWithPlugins({}, [
+  const app = await Application.bootstrapWithPlugins({
+    plugin: options.plugin
+  }, [
     new ArgumentsReader(0),
     new TypeDocReader(),
     new PackageJsonReader(),


### PR DESCRIPTION
typedoc: 0.25.0
docusaurus-plugin-typedoc: 0.20.0

the typedoc plugin does not load properly in that version.
this problem
docusaurus.config.js
It is reproduced when the plugin option is specified.

Since I don't know all the structures of this project, it's okay to close the PR.