### PR TITLE
fix: spaces in filenames results in broken links

### DIFF
--- a/packages/typedoc-gitlab-wiki-theme/src/theme.ts
+++ b/packages/typedoc-gitlab-wiki-theme/src/theme.ts
@@ -25,7 +25,7 @@ export class GitlabWikiTheme extends MarkdownTheme {
   }
 
   toUrl(mapping: any, reflection: DeclarationReflection) {
-    return `${mapping.directory}/${reflection.getFullName()}.md`;
+    return `${mapping.directory}/${reflection.getFullName().replace(/ /g, '-')}.md`;
   }
 
   onGitLabRendererEnd(renderer: RendererEvent) {


### PR DESCRIPTION
This fixes an issue I encountered when using the gitlab-wiki-theme.

The links that are generated have a `-` that replaces spaces in the referenced reflections, however the filenames of the relevant reflections still have spaces. This leads to all links with spaces being broken in the gitlab wiki.

This is on GitLab Enterprise Edition [v16.0.4-ee](https://gitlab.com/gitlab-org/gitlab/-/tags/v16.0.4-ee)

Using the following dependency tree:

```sh
> npm ls typedoc
my-package ~/my-package
├─┬ typedoc-gitlab-wiki-theme@1.1.0
│ └── typedoc@0.25.1 deduped
├─┬ typedoc-plugin-markdown@3.16.0
│ └── typedoc@0.25.1 deduped
└── typedoc@0.25.1
```