### PR TITLE
fix: CLI command skips unrelated plugins

### DIFF
--- a/packages/docusaurus-plugin-typedoc/src/plugin.ts
+++ b/packages/docusaurus-plugin-typedoc/src/plugin.ts
@@ -9,12 +9,14 @@ import { PluginOptions } from './types';
 // store list of plugin ids when running multiple instances
 const apps: string[] = [];
 
+const PLUGIN_NAME = 'docusaurus-plugin-typedoc';
+
 export default function pluginDocusaurus(
   context: LoadContext,
   opts: Partial<PluginOptions>,
 ) {
   return {
-    name: 'docusaurus-plugin-typedoc',
+    name: PLUGIN_NAME,
     async loadContent() {
       if (opts.id && !apps.includes(opts.id)) {
         apps.push(opts.id);
@@ -25,12 +27,12 @@ export default function pluginDocusaurus(
       cli
         .command('generate-typedoc')
         .description(
-          '(docusaurus-plugin-typedoc) Generate TypeDoc docs independently of the Docusaurus build process.',
+          `(${PLUGIN_NAME}) Generate TypeDoc docs independently of the Docusaurus build process.`,
         )
         .action(async () => {
           context.siteConfig?.plugins.forEach((pluginConfig) => {
             // Check PluginConfig is typed to [string, PluginOptions]
-            if (pluginConfig && typeof pluginConfig[1] === 'object') {
+            if (pluginConfig && typeof pluginConfig[1] === 'object' && pluginConfig[0] === PLUGIN_NAME) {
               generateTypedoc(context, pluginConfig[1]);
             }
           });


### PR DESCRIPTION
The generate-typedoc CLI command would run typedoc on every plugin instance defined on the site, not just for the current one. This would cause generation to fail with errors "Tried to set an option that was not declared", since the config for other plugins would not pass the validation for this plugin.

This fix checks that the plugin name matches the current one before running generateTypedoc on it.