### PR TITLE
Support MDX v2

### DIFF
--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -2,15 +2,15 @@ const path = require('path');
 module.exports = {
   modulePaths: ['<rootDir>/dist'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.test.json',
+      },
+    ],
   },
   verbose: true,
   setupFiles: [path.join(__dirname, 'jest.helpers.ts')],
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.test.json',
-    },
-  },
   maxWorkers: '1',
   testTimeout: 30000,
   updateSnapshot: false,

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/declaration-title.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/declaration-title.ts
@@ -44,9 +44,9 @@ export default function (theme: MarkdownTheme) {
       );
       if (this instanceof DeclarationReflection && this.typeParameters) {
         md.push(
-          `<${this.typeParameters
+          `&lt;${this.typeParameters
             .map((typeParameter) => `\`${typeParameter.name}\``)
-            .join(', ')}\\>`,
+            .join(', ')}&gt;`,
         );
       }
 

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/reflection-title.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/reflection-title.ts
@@ -21,7 +21,11 @@ export default function (theme: MarkdownTheme) {
           const typeParameters = this.model.typeParameters
             .map((typeParameter: ParameterReflection) => typeParameter.name)
             .join(', ');
-          title.push(`<${typeParameters}${shouldEscape ? '\\>' : '>'}`);
+          title.push(
+            `${shouldEscape ? '&lt;' : '<'}${typeParameters}${
+              shouldEscape ? '&gt;' : '>'
+            }`,
+          );
         }
       }
       return title.join('');

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/signature-title.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/signature-title.ts
@@ -29,9 +29,9 @@ export default function (theme: MarkdownTheme) {
 
       if (this.typeParameters) {
         md.push(
-          `<${this.typeParameters
+          `&lt;${this.typeParameters
             .map((typeParameter) => `\`${typeParameter.name}\``)
-            .join(', ')}\\>`,
+            .join(', ')}&gt;`,
         );
       }
       md.push(`(${getParameters(this.parameters)})`);

--- a/packages/typedoc-plugin-markdown/src/resources/helpers/type.ts
+++ b/packages/typedoc-plugin-markdown/src/resources/helpers/type.ts
@@ -158,7 +158,7 @@ function getDeclarationType(model: DeclarationReflection) {
             : ''
         }`;
       });
-    return `{ ${indexSignature ? indexSignature : ''}${
+    return `\\{ ${indexSignature ? indexSignature : ''}${
       types ? types.join('; ') : ''
     } }${
       model.defaultValue && model.defaultValue !== '...'
@@ -172,9 +172,9 @@ function getDeclarationType(model: DeclarationReflection) {
 export function getFunctionType(modelSignatures: SignatureReflection[]) {
   const functions = modelSignatures.map((fn) => {
     const typeParams = fn.typeParameters
-      ? `<${fn.typeParameters
+      ? `&lt;${fn.typeParameters
           .map((typeParameter) => typeParameter.name)
-          .join(', ')}\\>`
+          .join(', ')}&gt;`
       : [];
     const params = fn.parameters
       ? fn.parameters.map((param) => {
@@ -210,9 +210,9 @@ function getReferenceType(model: ReferenceType, emphasis) {
     }
     if (model.typeArguments && model.typeArguments.length > 0) {
       reflection.push(
-        `<${model.typeArguments
+        `&lt;${model.typeArguments
           .map((typeArgument) => Handlebars.helpers.type.call(typeArgument))
-          .join(', ')}\\>`,
+          .join(', ')}&gt;`,
       );
     }
     return reflection.join('');

--- a/packages/typedoc-plugin-markdown/src/utils.ts
+++ b/packages/typedoc-plugin-markdown/src/utils.ts
@@ -18,7 +18,9 @@ export function formatContents(contents: string) {
 
 export function escapeChars(str: string) {
   return str
-    .replace(/>/g, '\\>')
+    .replace(/>/g, '&gt;')
+    .replace(/</g, '&lt;')
+    .replace(/\{/g, '\\{')
     .replace(/_/g, '\\_')
     .replace(/`/g, '\\`')
     .replace(/\|/g, '\\|');


### PR DESCRIPTION
This PR adjusts the output of `typedoc-plugin-markdown` to be compatible with MDX v2. Most of the changes are `<` → `&lt;` and `>` → `&gt;`.

In my limited testing, these changes maintain compatibility with MDX v1.

I wasn't able to get the tests to pass in this repo—which may be a setup issue on my machine—but I did get rid of the warning about configuring `ts-jest` via the `globals` property.