### PR TITLE
fix: provide correct types for partials

### DIFF
--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/breadcrumbs.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/breadcrumbs.ts
@@ -7,7 +7,7 @@ import { escapeChars } from '../utils';
 export function breadcrumbs(
   context: MarkdownThemeRenderContext,
   page: MarkdownPageEvent<ProjectReflection | DeclarationReflection>,
-) {
+): string {
   const md: string[] = [];
 
   const fileExtension = context.options.getValue('useMDXFileExt')

--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/comment.parts.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/comment.parts.ts
@@ -6,7 +6,7 @@ import { getRelativeUrl } from '../utils';
 export function commentParts(
   context: MarkdownThemeRenderContext,
   parts: CommentDisplayPart[],
-) {
+): string {
   const md: string[] = [];
   const parsedText = (text: string) => {
     const mediaPattern = /media:\/\/([^ ")\]}]+)/g;

--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/list.parameters.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/list.parameters.ts
@@ -6,7 +6,7 @@ import { escapeChars } from '../utils';
 export function parametersList(
   context: MarkdownThemeRenderContext,
   parameters: ParameterReflection[],
-) {
+): string {
   const parseParams = (current: any, acc: any) => {
     const shouldFlatten =
       current.type?.declaration?.kind === ReflectionKind.TypeLiteral &&

--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/member.declaration.identifier.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/member.declaration.identifier.ts
@@ -6,7 +6,7 @@ import { escapeChars, stripComments } from '../utils';
 export function declarationMemberIdentifier(
   context: MarkdownThemeRenderContext,
   reflection: DeclarationReflection,
-) {
+): string {
   const md: string[] = [];
 
   const useCodeBlocks = context.options.getValue('useCodeBlocks');

--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/member.declaration.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/member.declaration.ts
@@ -13,7 +13,7 @@ export function declarationMember(
   declaration: DeclarationReflection,
   headingLevel: number,
   nested = false,
-) {
+): string {
   const md: string[] = [];
 
   md.push(context.partials.reflectionFlags(declaration));

--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/member.type-declaration.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/member.type-declaration.ts
@@ -6,7 +6,7 @@ export function typeDeclarationMember(
   typeDeclaration: DeclarationReflection,
   headingLevel: number,
   parentDeclaration?: DeclarationReflection,
-) {
+): string {
   const md: string[] = [];
 
   if (typeDeclaration.children) {

--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/table.parameters.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/table.parameters.ts
@@ -6,7 +6,7 @@ import { formatTableDescriptionCol, formatTableTypeCol } from '../utils';
 export function parametersTable(
   context: MarkdownThemeRenderContext,
   parameters: ParameterReflection[],
-) {
+): string {
   const parseParams = (current: any, acc: any) => {
     const shouldFlatten =
       current.type?.declaration?.kind === ReflectionKind.TypeLiteral &&

--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/type-argumentsts.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/type-argumentsts.ts
@@ -10,7 +10,7 @@ export function typeArguments(
     .map((typeArgument) =>
       typeArgument instanceof ReflectionType
         ? context.partials.reflectionType(typeArgument, foreCollpase)
-        : context.partials.someType(typeArgument, foreCollpase),
+        : context.partials.someType(typeArgument),
     )
     .join(', ')}\\>`;
 }

--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/type.declaration.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/type.declaration.ts
@@ -5,7 +5,7 @@ import { backTicks } from '../markdown';
 export function declarationType(
   context: MarkdownThemeRenderContext,
   declarationReflection: DeclarationReflection,
-) {
+): string {
   const shouldFormat = context.options.getValue('useCodeBlocks');
 
   if (declarationReflection.indexSignature || declarationReflection.children) {

--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/type.reference.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/type.reference.ts
@@ -5,7 +5,7 @@ import { backTicks } from '../markdown';
 export function referenceType(
   context: MarkdownThemeRenderContext,
   referenceType: ReferenceType,
-) {
+): string {
   if (
     referenceType.reflection ||
     (referenceType.name && referenceType.typeArguments)

--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/type.reflection.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/type.reflection.ts
@@ -6,7 +6,7 @@ export function reflectionType(
   context: MarkdownThemeRenderContext,
   reflectionType: ReflectionType,
   foreCollpase = false,
-) {
+): string {
   const root =
     reflectionType instanceof ReflectionType
       ? reflectionType.declaration

--- a/packages/typedoc-plugin-markdown/src/theme/resources/partials/type.some.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/resources/partials/type.some.ts
@@ -21,7 +21,7 @@ import { backTicks } from '../markdown';
 export function someType(
   context: MarkdownThemeRenderContext,
   someType: SomeType,
-) {
+): string {
   if (!someType) {
     return '';
   }


### PR DESCRIPTION
This PR fixes the TS typing for `MarkdownThemeRenderContext.partials`. 

**Before**



```ts
// dist/theme/theme-render-context.d.ts

    /**
     * The theme's global partials context.
     */
    partials: any;
```

**After**

```ts
// dist/theme/theme-render-context.d.ts

    /**
     * The theme's global partials context.
     */
    partials: {
        breadcrumbs: (page: MarkdownPageEvent<import("typedoc").DeclarationReflection | import("typedoc").ProjectReflection>) => string;
        commentParts: (parts: import("typedoc").CommentDisplayPart[]) => string;
        ...
```

