### PR TITLE
fix: exit code 1 when typedoc is failing

### DIFF
--- a/packages/docusaurus-plugin-typedoc/src/plugin.ts
+++ b/packages/docusaurus-plugin-typedoc/src/plugin.ts
@@ -106,7 +106,7 @@ module.exports = typedocSidebar.items;`,
     console.error(
       '[docusaurus-plugin-typedoc] TypeDoc exited with an error. Use the "skipErrorChecking" option to disable TypeDoc error checking.',
     );
-    process.exit();
+    process.exit(1);
   }
 
   if (app.options.getValue('watch')) {


### PR DESCRIPTION
Fixes https://github.com/tgreyuk/typedoc-plugin-markdown/issues/583