### PR TITLE
Use remark.process instead of remark.processSync

### DIFF
--- a/packages/typedoc-plugin-remark/src/remark.cjs
+++ b/packages/typedoc-plugin-remark/src/remark.cjs
@@ -32,7 +32,7 @@ module.exports = {
     pluginRefs.forEach((pluginRef) => {
       processor.use(pluginRef.pluginFn, pluginRef.options);
     });
-    processor.processSync(file);
+    await processor.process(file);
 
     writeSync(file);
   },


### PR DESCRIPTION
Hi,

I have been using the typedoc-plugin-markdown plugin for some time and stubled across a problem where I needed to rewrite relative links from `myMarkDownFile.md` to `./myMarkDownFile.md`. In my attempt to find a solution to do that I came across the next branch of your repository.

While trying it out, I encountered this error:

```
Error: `processSync` finished async. Use `process` instead
    at assertDone (file:///Users/<retracted>javascript/core-api/node_modules/unified/lib/index.js:1273:11)
    at Function.processSync (file:///Users/<retracted>/javascript/core-api/node_modules/unified/lib/index.js:820:5)
    at parseContents (/Users/<retracted>/javascript/core-api/node_modules/typedoc-plugin-remark/dist/remark.cjs:35:15)
    at async /Users/<retracted>/javascript/core-api/node_modules/typedoc-plugin-remark/dist/index.js:75:24
    at async Promise.all (index 0)
    at async /Users/<retracted>/javascript/core-api/node_modules/typedoc-plugin-remark/dist/index.js:72:13
    at async Promise.all (index 0)
    at async _classThis.render (/Users/<retracted>/javascript/core-api/node_modules/typedoc-plugin-markdown/dist/app/renderer/overrides.js:117:9)
    at async _classThis.generateDocs (/Users/<retracted>/javascript/core-api/node_modules/typedoc-plugin-markdown/dist/app/renderer/overrides.js:45:5)
    at async run (/Users/<retracted>/javascript/core-api/node_modules/typedoc/dist/lib/cli.js:118:13)
```

I have no idea if this fits into your plans, or if its the correct solution, but this PR changes the usage of remark to utilise the `process`(async) function instead of `processSync`.

 Merge it if its helps you, or discard it if that suits you better :)