### PR TITLE
fix: Prevent crash in typeDeclarationTable

### DIFF
--- a/packages/typedoc-plugin-markdown/src/theme/context/partials/member.typeDeclarationTable.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/partials/member.typeDeclarationTable.ts
@@ -119,7 +119,7 @@ export function typeDeclarationTable(
           }),
         );
       }
-      if ((declaration.type as any).declaration?.signatures?.length) {
+      if (declaration.type && (declaration.type as any).declaration?.signatures?.length) {
         (declaration.type as any).declaration?.signatures.forEach((sig) => {
           if (sig.comment) {
             commentsOut.push(


### PR DESCRIPTION
**Fix: guard against undefined `declaration.type` in `typeDeclarationTable`**

When generating markdown for certain `type-alias` pages (e.g. a large state type with nested objects), `typedoc-plugin-markdown` can crash with:

```text
TypeError: Cannot read properties of undefined (reading 'declaration')
    at member.typeDeclarationTable.js:75
```

This happens because `member.typeDeclarationTable` assumes `declaration.type` is always defined:

```js
if (declaration.type.declaration?.signatures?.length) {
  declaration.type.declaration.signatures.forEach(/* ... */);
}
```

but for some flattened declarations `declaration.type` is `undefined`.

This PR adds a small null‑check:

```js
if (declaration.type && declaration.type.declaration?.signatures?.length) {
  declaration.type.declaration.signatures.forEach(/* ... */);
}
```

so those entries fall back to the regular type-rendering path without throwing. It fixes the crash while preserving the existing output format for all declarations that do have a type.