### PR TITLE
fix(vitepress): skip fenced code blocks in link-encoding regex

### DIFF
--- a/packages/typedoc-vitepress-theme/src/index.ts
+++ b/packages/typedoc-vitepress-theme/src/index.ts
@@ -38,7 +38,21 @@ export function load(app: MarkdownApplication) {
   );
 
   app.renderer.on(MarkdownPageEvent.END, (page) => {
-    page.contents = page.contents?.replace(
+    if (!page.contents) return;
+
+    const codeBlocks: string[] = [];
+    const placeholder = '___TYPEDOC_CODEBLOCK___';
+
+    // Protect fenced code blocks from the link regex
+    let contents = page.contents.replace(
+      /```[\s\S]*?```/g,
+      (match: string) => {
+        codeBlocks.push(match);
+        return placeholder;
+      },
+    );
+
+    contents = contents.replace(
       /\[([^\]]+)\]\((?!https?:|\/|\.)([^)]*#?[^)]*)\)/g,
       (match: string, text: string, url: string) => {
         const urlWithAnchor = url.split('#');
@@ -48,6 +62,12 @@ export function load(app: MarkdownApplication) {
         }
         return `[${text}](${encodeURI(url)})`;
       },
+    );
+
+    // Restore fenced code blocks
+    page.contents = contents.replace(
+      new RegExp(placeholder, 'g'),
+      () => codeBlocks.shift() || '',
     );
   });
 


### PR DESCRIPTION
## Summary

The `MarkdownPageEvent.END` handler in `typedoc-vitepress-theme` applies `encodeURI()` to relative Markdown link URLs, but the regex runs against the **entire** page contents — including fenced code blocks. Any `[...](...)`-shaped substring inside a code fence is misidentified as a link and URL-encoded.

For example, a JavaScript regex `/^[^./](?!:[/\\])/` inside a fenced code block is mangled to `/^[^./](?!:%5B/%5C%5C%5D)/` because `[^./](?!:[/\\])` matches the `[text](url)` link pattern.

## Root cause

```
Code block content:   [^./](?!:[/\\])
                      └─┬─┘└───┬────┘
Regex interprets as: [text](   url   )

encodeURI("?!:[/\\]") → "?!:%5B/%5C%5C%5D"
```

The link regex `/\[([^\]]+)\]\((?!https?:|\/|\.)([^)]*#?[^)]*)\)/g` has no awareness of fenced code block boundaries.

## Fix

Protect fenced code blocks with placeholders before running the link regex, then restore them afterward. This is the same approach used by `sanitizeComments` in `typedoc-plugin-markdown`.

## Verification

- All 5 existing tests pass
- Tested with a reproduction case using `{@include}` injecting a markdown file containing `/^[^./](?!:[/\\])/`:
  - **Before fix:** `(?!:%5B/%5C%5C%5D)` (URL-encoded)
  - **After fix:** `(?!:[/\\])` (preserved correctly)
- Tested with both TypeDoc 0.28.14 and 0.28.19, typedoc-plugin-markdown 4.9.0 and 4.11.0

## Related

- Fixes #862
- Fixes [rolldown/rolldown#8792](https://github.com/rolldown/rolldown/issues/8792)
- Rolldown workaround PR: [rolldown/rolldown#9218](https://github.com/rolldown/rolldown/pull/9218)
