### PR TITLE
Render parameter-target links as plain text

### DIFF
--- a/packages/typedoc-plugin-markdown/src/theme/context/helpers/get-comment-parts.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/helpers/get-comment-parts.ts
@@ -32,7 +32,7 @@ export function getCommentParts(
                 if (this.router.hasUrl(part.target)) {
                   url = getReflectionUrl(this, part.target);
                 }
-                if (typeof url === 'undefined') {
+                if (typeof url === 'undefined' && !part.target.isParameter()) {
                   let target = part.target.parent!;
                   while (!this.router.hasUrl(target)) {
                     target = target.parent!;

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/comments/comments.members.opts-1.-functions-parametersTable.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/comments/comments.members.opts-1.-functions-parametersTable.md.snap
@@ -17,7 +17,7 @@ Adds two numbers together.
 | Parameter | Type | Default value | Description |
 | ------ | ------ | ------ | ------ |
 | `param1` | `number` | `undefined` | The first param to be added. |
-| `param2` | `number` | `undefined` | The second param to be added. Some additional text for num2. |
+| `param2` | `number` | `undefined` | The second param to be added. See param1. Some additional text for num2. |
 | `param3` | `number` | `4` | The third param to be added. |
 
 ## Returns

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/comments/comments.members.opts-2.-Function.parametersTable.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/comments/comments.members.opts-2.-Function.parametersTable.md.snap
@@ -1,0 +1,104 @@
+# Function: parametersTable()
+
+> **parametersTable**\<`T`\>(`param1`, `param2`, `param3?`): `number`
+
+Defined in: [index.ts:1](http://source-url)
+
+Adds two numbers together.
+
+## Type Parameters
+
+<table>
+<thead>
+<tr>
+<th align="left">Type Parameter</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+
+`T`
+
+</td>
+<td>
+
+The type of the numbers to be added.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+## Parameters
+
+<table>
+<thead>
+<tr>
+<th align="left">Parameter</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+
+`param1`
+
+</td>
+<td>
+
+`number`
+
+</td>
+<td>
+
+The first param
+to be added.
+
+</td>
+</tr>
+<tr>
+<td>
+
+`param2`
+
+</td>
+<td>
+
+`number`
+
+</td>
+<td>
+
+The second param to be added. See param1.
+
+Some additional text for num2.
+
+</td>
+</tr>
+<tr>
+<td>
+
+`param3`
+
+</td>
+<td>
+
+`number`
+
+</td>
+<td>
+
+The third param to be added.
+
+</td>
+</tr>
+</tbody>
+</table>
+
+## Returns
+
+`number`

--- a/packages/typedoc-plugin-markdown/test/fixtures/src/comments/index.ts
+++ b/packages/typedoc-plugin-markdown/test/fixtures/src/comments/index.ts
@@ -282,7 +282,7 @@ export const TypeDeclarationConst = {
  *
  * @param param1 The first param
  * to be added.
- * @param param2 The second param to be added.
+ * @param param2 The second param to be added. See {@link param1}.
  *
  * Some additional text for num2.
  *

--- a/packages/typedoc-plugin-markdown/test/specs/comments.spec.ts
+++ b/packages/typedoc-plugin-markdown/test/specs/comments.spec.ts
@@ -45,7 +45,10 @@ describe(`typedoc-plugin-markdown (Integration / Comments)`, () => {
   });
 
   it(`should get tables for parameters`, () => {
-    expectFileToEqual('comments', 'members', ['/functions/parametersTable.md']);
+    expectFileToEqual('comments', 'members', [
+      '/functions/parametersTable.md',
+      '/Function.parametersTable.md',
+    ]);
   });
 
   it(`should get tables for type declarations`, () => {


### PR DESCRIPTION
Inline `{@link param}` references inside parameter descriptions could render as broken links because the helper walked up to the nearest parent with a URL.

This lets parameter-target links fall through to the plain-text path instead of linking to the parent reflection. I checked the updated snapshots and the workspace test suite with 264 tests passing.

Fixes #870