### PR TITLE
fix(core): escape pipes in @defaultValue content for property tables

### DIFF
--- a/.changeset/escape-default-value-pipes.md
+++ b/.changeset/escape-default-value-pipes.md
@@ -1,0 +1,5 @@
+---
+"typedoc-plugin-markdown": patch
+---
+
+Fixed unescaped pipe characters in `@defaultValue` tag content breaking the properties table layout.

--- a/packages/typedoc-plugin-markdown/src/theme/context/helpers/get-property-default-value.spec.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/helpers/get-property-default-value.spec.ts
@@ -1,0 +1,30 @@
+import { strict as assert } from 'assert';
+import { DeclarationReflection } from 'typedoc';
+import { getPropertyDefaultValue } from './get-property-default-value.js';
+
+describe('typedoc-plugin-markdown (Helpers / getPropertyDefaultValue)', () => {
+  it('should escape pipes in a @defaultValue tag so they do not break the table row', () => {
+    const model = {
+      comment: {
+        blockTags: [{ tag: '@defaultValue', content: [{ text: '`0 | 1`' }] }],
+      },
+    } as unknown as DeclarationReflection;
+    assert.strictEqual(getPropertyDefaultValue(model), '`0 \\| 1`');
+  });
+
+  it('should escape pipes in plain-text @defaultValue content', () => {
+    const model = {
+      comment: {
+        blockTags: [{ tag: '@defaultValue', content: [{ text: '"a" | "b"' }] }],
+      },
+    } as unknown as DeclarationReflection;
+    assert.strictEqual(getPropertyDefaultValue(model), '"a" \\| "b"');
+  });
+
+  it('should wrap an inferred default value with backTicks (escaping pipes)', () => {
+    const model = {
+      defaultValue: 'READ | WRITE',
+    } as unknown as DeclarationReflection;
+    assert.strictEqual(getPropertyDefaultValue(model), 'READ \\| WRITE');
+  });
+});

--- a/packages/typedoc-plugin-markdown/src/theme/context/helpers/get-property-default-value.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/helpers/get-property-default-value.ts
@@ -6,7 +6,10 @@ export function getPropertyDefaultValue(model: DeclarationReflection) {
     (tag) => tag.tag === '@defaultValue',
   );
   if (defaultValueTag) {
-    return defaultValueTag?.content.map((content) => content.text).join('');
+    return defaultValueTag?.content
+      .map((content) => content.text)
+      .join('')
+      .replace(/\|/g, '\\|');
   }
   return model.defaultValue && model.defaultValue !== '...'
     ? backTicks(model.defaultValue)


### PR DESCRIPTION
## Summary

The `@defaultValue` branch of `getPropertyDefaultValue` returns the tag text verbatim, and that string is placed straight into the "Default value" cell of the properties table (`member.propertiesTable.ts`). When the tag contains a literal `|`, the pipe is read as a column delimiter, so the row ends up with more cells than the header and the table layout breaks (anything after the pipe spills into an extra column).

This escapes `|` as `\|` in that branch. The other branch of the same function already passes inferred defaults through `backTicks()` (which escapes `|`), and the comment column is escaped via `escapeChars`, so this just brings the `@defaultValue` path in line with the other cells in the same table.

## Motivation

A property documented like this:

```ts
interface Options {
  /** @defaultValue `0 | 1` */
  mode: number;
}
```

currently renders a row with four cells against a three-column header:

```md
| Property | Type | Default value |
| ------ | ------ | ------ |
| `mode` | `number` | `0 | 1` |
```

The GFM tables spec requires a pipe to be escaped as `\|` even inside a code span in a cell, so the escaped output `` `0 \| 1` `` renders as intended.

## Related

None.

## Validation

- [x] Tests added (`get-property-default-value.spec.ts`, following the existing util-spec pattern)
- Existing snapshots are unchanged, since no current fixture uses a `@defaultValue` containing a pipe.
- Changeset added.
