### PR TITLE
fix(core): fix signature parameters (#874)

### DIFF
--- a/packages/typedoc-plugin-markdown/src/theme/context/partials/member.signatureParameters.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/partials/member.signatureParameters.ts
@@ -21,7 +21,7 @@ export function signatureParameters(
         const optional =
           param.flags.isOptional || param.defaultValue ? '?' : '';
 
-        const rest = param.flags?.isRest ? "..." : "";
+        const rest = param.flags?.isRest ? '...' : '';
         const paramItem = [`${rest}${backTicks(`${param.name}${optional}`)}`];
         if (showParamType) {
           paramItem.push(paramType);
@@ -32,6 +32,6 @@ export function signatureParameters(
         return paramsmd.join('');
       })
       .join(`, `) +
-    ')'
+    (format && model.length > 2 ? `\n)` : ')')
   );
 }

--- a/packages/typedoc-plugin-markdown/src/theme/context/partials/member.signatureParameters.ts
+++ b/packages/typedoc-plugin-markdown/src/theme/context/partials/member.signatureParameters.ts
@@ -14,9 +14,6 @@ export function signatureParameters(
     model
       .map((param) => {
         const paramsmd: string[] = [];
-        if (param.flags?.isRest) {
-          paramsmd.push('...');
-        }
         const paramType = this.partials.someType(param.type as SomeType);
         const showParamType =
           (options?.forceExpandParameters ?? false) ||
@@ -24,7 +21,8 @@ export function signatureParameters(
         const optional =
           param.flags.isOptional || param.defaultValue ? '?' : '';
 
-        const paramItem = [`${backTicks(`${param.name}${optional}`)}`];
+        const rest = param.flags?.isRest ? "..." : "";
+        const paramItem = [`${rest}${backTicks(`${param.name}${optional}`)}`];
         if (showParamType) {
           paramItem.push(paramType);
         }

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/objectsAndParams/objectsAndParams.members.opts-2.functions-functionWithNestedParameters.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/objectsAndParams/objectsAndParams.members.opts-2.functions-functionWithNestedParameters.md.snap
@@ -14,7 +14,8 @@ function functionWithNestedParameters(
   parent?: number;
 }, 
    context: any, 
-   somethingElse?: string): boolean;
+   somethingElse?: string
+): boolean;
 ```
 
 Some nested params.

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-1.functions-functionWithComplexParams.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-1.functions-functionWithComplexParams.md.snap
@@ -4,7 +4,7 @@
 
 Defined in: [functions.ts:1](http://source-url)
 
-Function with function parmas
+Function with function params
 
 ## Parameters
 

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-1.functions-functionWithRestParams.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-1.functions-functionWithRestParams.md.snap
@@ -1,6 +1,6 @@
 # Function: functionWithRestParams()
 
-> **functionWithRestParams**(`param`, ...`restParams`): `boolean`
+> **functionWithRestParams**(`param1`, `param2`, ...`restParams`): `boolean`
 
 Defined in: [functions.ts:1](http://source-url)
 
@@ -8,7 +8,11 @@ Function with rest params
 
 ## Parameters
 
-### param
+### param1
+
+`string`
+
+### param2
 
 `string`
 

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-1.functions-functionWithRestParams.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-1.functions-functionWithRestParams.md.snap
@@ -4,7 +4,7 @@
 
 Defined in: [functions.ts:1](http://source-url)
 
-Function with reset parmas
+Function with rest params
 
 ## Parameters
 

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.README.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.README.md.snap
@@ -129,13 +129,13 @@ Module comments
 | [functionWithArrayOfOptionalStuff](functions/functionWithArrayOfOptionalStuff.md) | Comments for array of stuff? |
 | [functionWithArrayOfStuff](functions/functionWithArrayOfStuff.md) | Comments for array of stuff |
 | [functionWithArrayOfUnionStuff](functions/functionWithArrayOfUnionStuff.md) | Comments for array of union stuff |
-| [functionWithComplexParams](functions/functionWithComplexParams.md) | Function with function parmas |
+| [functionWithComplexParams](functions/functionWithComplexParams.md) | Function with function params |
 | [functionWithDefaultParameters](functions/functionWithDefaultParameters.md) | This is a function with a parameter that has a default value. |
 | [functionWithMultipleSignatures](functions/functionWithMultipleSignatures.md) | Main function comment. |
 | [functionWithNamedParams](functions/functionWithNamedParams.md) | - |
 | [functionWithNestedParameters](functions/functionWithNestedParameters.md) | Some nested params. |
 | [functionWithOptionalParameters](functions/functionWithOptionalParameters.md) | This is a function with a parameters. |
-| [functionWithRestParams](functions/functionWithRestParams.md) | Function with reset parmas |
+| [functionWithRestParams](functions/functionWithRestParams.md) | Function with rest params |
 | [functionWithTypeParameters](functions/functionWithTypeParameters.md) | Function with type parameters |
 | [functionWithUnionParams](functions/functionWithUnionParams.md) | - |
 | [tupleTypeFunction](functions/tupleTypeFunction.md) | - |

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithComplexParams.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithComplexParams.md.snap
@@ -6,7 +6,7 @@ function functionWithComplexParams(paramA: (a: string) => true, paramB: object):
 
 Defined in: [functions.ts:1](http://source-url)
 
-Function with function parmas
+Function with function params
 
 ## Parameters
 

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithDefaultParameters.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithDefaultParameters.md.snap
@@ -7,7 +7,8 @@ function functionWithDefaultParameters(
    valueC?: number, 
    valueD?: boolean, 
    valueE?: boolean, 
-   valueF?: string): string;
+   valueF?: string
+): string;
 ```
 
 Defined in: [functions.ts:1](http://source-url)

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithNestedParameters.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithNestedParameters.md.snap
@@ -4,7 +4,8 @@
 function functionWithNestedParameters(
    params: object, 
    context: any, 
-   somethingElse?: string): boolean;
+   somethingElse?: string
+): boolean;
 ```
 
 Defined in: [functions.ts:1](http://source-url)

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithOptionalParameters.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithOptionalParameters.md.snap
@@ -5,7 +5,8 @@ function functionWithOptionalParameters(
    firstParamWithDefault?: boolean, 
    requiredParam: string, 
    optionalParam?: string, 
-   paramWithDefault?: number): void;
+   paramWithDefault?: number
+): void;
 ```
 
 Defined in: [functions.ts:1](http://source-url)

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithRestParams.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithRestParams.md.snap
@@ -6,7 +6,7 @@ function functionWithRestParams(param: string, ...restParams: string[]): boolean
 
 Defined in: [functions.ts:1](http://source-url)
 
-Function with reset parmas
+Function with rest params
 
 ## Parameters
 

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithRestParams.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithRestParams.md.snap
@@ -1,7 +1,10 @@
 # Function: functionWithRestParams()
 
 ```ts
-function functionWithRestParams(param: string, ...restParams: string[]): boolean;
+function functionWithRestParams(
+   param1: string, 
+   param2: string, ...
+   restParams: string[]): boolean;
 ```
 
 Defined in: [functions.ts:1](http://source-url)
@@ -12,7 +15,8 @@ Function with rest params
 
 | Parameter | Type |
 | :------ | :------ |
-| `param` | `string` |
+| `param1` | `string` |
+| `param2` | `string` |
 | ...`restParams` | `string`[] |
 
 ## Returns

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithRestParams.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithRestParams.md.snap
@@ -3,8 +3,8 @@
 ```ts
 function functionWithRestParams(
    param1: string, 
-   param2: string, ...
-   restParams: string[]): boolean;
+   param2: string, 
+   ...restParams: string[]): boolean;
 ```
 
 Defined in: [functions.ts:1](http://source-url)

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithRestParams.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithRestParams.md.snap
@@ -4,7 +4,8 @@
 function functionWithRestParams(
    param1: string, 
    param2: string, 
-   ...restParams: string[]): boolean;
+   ...restParams: string[]
+): boolean;
 ```
 
 Defined in: [functions.ts:1](http://source-url)

--- a/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithUnionParams.md.snap
+++ b/packages/typedoc-plugin-markdown/test/__snapshots__/reflections/reflections.members.opts-2.functions-functionWithUnionParams.md.snap
@@ -28,7 +28,8 @@ function functionWithUnionParams(
      z: string;
   };
 }, 
-   noUnions: string): undefined;
+   noUnions: string
+): undefined;
 ```
 
 Defined in: [functions.ts:1](http://source-url)

--- a/packages/typedoc-plugin-markdown/test/fixtures/src/reflections/functions.ts
+++ b/packages/typedoc-plugin-markdown/test/fixtures/src/reflections/functions.ts
@@ -101,14 +101,14 @@ export function functionWithNamedParams(
 ) {}
 
 /**
- * Function with reset parmas
+ * Function with rest params
  */
 export function functionWithRestParams(param: string, ...restParams: string[]) {
   return true;
 }
 
 /**
- * Function with function parmas
+ * Function with function params
  */
 export function functionWithComplexParams(
   paramA: (a: string) => true,

--- a/packages/typedoc-plugin-markdown/test/fixtures/src/reflections/functions.ts
+++ b/packages/typedoc-plugin-markdown/test/fixtures/src/reflections/functions.ts
@@ -103,7 +103,11 @@ export function functionWithNamedParams(
 /**
  * Function with rest params
  */
-export function functionWithRestParams(param: string, ...restParams: string[]) {
+export function functionWithRestParams(
+  param1: string,
+  param2: string,
+  ...restParams: string[]
+) {
   return true;
 }
 


### PR DESCRIPTION
## Summary

On multi-lines signatures, avoid orphaned "rest dots", and move closing parenthesis in a new line.
(plus a couple of typos in a test file: "parmas" => params" and "reset" => "rest")

## Motivation

* The "rest dots" [were added as a separate entry in the `paramsmd` array](https://github.com/typedoc2md/typedoc-plugin-markdown/blob/main/packages/typedoc-plugin-markdown/src/theme/context/partials/member.signatureParameters.ts#L17-L19), thus when the signature is multi-lines, they were orphaned at the end of a line with their associated parameter on the new line by [the join adding newlines](https://github.com/typedoc2md/typedoc-plugin-markdown/blob/main/packages/typedoc-plugin-markdown/src/theme/context/partials/member.signatureParameters.ts#L32). This resulted in a signature like:
    ```ts
    function functionWithRestParams(
   param1: string, 
   param2: string, ...
   restParams: string[]): boolean;
    ```
    This was presumably not detected earlier because the test case for `functionWithRestParams` only had 2 parameters, thus did not trigger the multi-lines display.
* The closing parenthesis (and return type) of multi-lines signatures [was added at the end of the last line](https://github.com/typedoc2md/typedoc-plugin-markdown/blob/main/packages/typedoc-plugin-markdown/src/theme/context/partials/member.signatureParameters.ts#L37). This does not match what prettier is doing (closing parenthesis and return type on a new line), and in some cases (not sure when exactly since I couldn't reproduce it in this PR) unindented the last parameter (and the last line). This PR adds a new line with the same test that is used to detect multi-lines display (might be refactored in a single variable to ensure they stay in sync).

## Related

Resolves https://github.com/typedoc2md/typedoc-plugin-markdown/issues/874

## Validation

- [X] Tests added or updated where relevant
- [ ] Documentation updated where relevant
- [ ] Breaking changes documented where relevant
